### PR TITLE
Add whole-document parsing, try to conform to orgmode syntax draft, generic aeson, add a couple tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: haskell
 ghc: 7.8.3
 script:
+  - sudo apt-get install libgmp-dev
   - cabal configure --enable-tests
   - cabal build
   - cabal test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
 language: haskell
-ghc: 7.8.3
-script:
-  - sudo apt-get install libgmp-dev
-  - cabal configure --enable-tests
-  - cabal build
-  - cabal test
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,4 @@
 language: haskell
 ghc: 7.8.4
-script:
-  - cabal sandbox init
-  - cabal install --only-dependencies --enable-tests
-  - cabal configure --enable-tests
-  - cabal build
-  - cabal test
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: haskell
+ghc: 7.8.4
+script:
+  - cabal sandbox init
+  - cabal install --only-dependencies --enable-tests
+  - cabal configure --enable-tests
+  - cabal build
+  - cabal test
 notifications:
   email: false

--- a/orgmode-parse.cabal
+++ b/orgmode-parse.cabal
@@ -37,7 +37,8 @@ Library
     Data.OrgMode.Parse.Types
 
   Build-Depends:
-                  attoparsec                >= 0.12     && < 0.13
+                  aeson
+                , attoparsec                >= 0.12     && < 0.13
                 , base                      >= 4.4      && < 5
                 , bytestring
                 , containers                >= 0.5.5    && < 0.6

--- a/orgmode-parse.cabal
+++ b/orgmode-parse.cabal
@@ -37,10 +37,10 @@ Library
     Data.OrgMode.Parse.Types
 
   Build-Depends:
-                  aeson
+                  aeson                     >= 0.8.0.2  && < 0.9
                 , attoparsec                >= 0.12     && < 0.13
                 , base                      >= 4.4      && < 5
-                , bytestring
+                , bytestring                >= 0.10.4   && < 0.11
                 , containers                >= 0.5.5    && < 0.6
                 , free                      >= 4.9      && < 5
                 , hashable                  >= 1.2      && < 1.3
@@ -60,11 +60,11 @@ Test-Suite tests
 
   Build-Depends:
     base                       >= 4.4      && < 5,
-    aeson,
-    bytestring,
+    aeson                      >= 0.8      && < 0.9,
+    bytestring                 >= 0.10     && < 0.11,
     text                       >= 1.0      && < 2.0,
     attoparsec                 >= 0.12     && < 0.13,
-    hashable,
+    hashable                   >= 1.2      && < 1.3,
     unordered-containers       >= 0.2      && < 0.3,
     thyme                      >= 0.3      && < 0.4,
     old-locale                 >= 1.0      && < 2.0,

--- a/orgmode-parse.cabal
+++ b/orgmode-parse.cabal
@@ -1,5 +1,5 @@
 Name:                   orgmode-parse
-Version:                0.0.2.1
+Version:                0.0.2.2
 Author:                 Parnell Springmeyer <parnell@digitalmentat.com>
 Maintainer:             Parnell Springmeyer <parnell@digitalmentat.com>
 License:                BSD3
@@ -37,13 +37,15 @@ Library
     Data.OrgMode.Parse.Types
 
   Build-Depends:
-    base                      >= 4.4      && < 5,
-    attoparsec                >= 0.12     && < 0.13,
-    unordered-containers      >= 0.2      && < 0.3,
-    thyme                     >= 0.3      && < 0.4,
-    old-locale                >= 1.0      && < 2.0,
-    free                      >= 4.9      && < 5,
-    text                      >= 1.0      && < 2.0
+                  attoparsec                >= 0.12     && < 0.13
+                , base                      >= 4.4      && < 5
+                , bytestring
+                , containers                >= 0.5.5    && < 0.6
+                , free                      >= 4.9      && < 5
+                , old-locale                >= 1.0      && < 2.0
+                , text                      >= 1.0      && < 2.0
+                , thyme                     >= 0.3      && < 0.4
+                , unordered-containers      >= 0.2      && < 0.3
 
 Test-Suite tests
   Type:                 exitcode-stdio-1.0

--- a/orgmode-parse.cabal
+++ b/orgmode-parse.cabal
@@ -1,5 +1,5 @@
 Name:                   orgmode-parse
-Version:                0.0.2.2
+Version:                0.1.0
 Author:                 Parnell Springmeyer <parnell@digitalmentat.com>
 Maintainer:             Parnell Springmeyer <parnell@digitalmentat.com>
 License:                BSD3

--- a/orgmode-parse.cabal
+++ b/orgmode-parse.cabal
@@ -60,8 +60,11 @@ Test-Suite tests
 
   Build-Depends:
     base                       >= 4.4      && < 5,
+    aeson,
+    bytestring,
     text                       >= 1.0      && < 2.0,
     attoparsec                 >= 0.12     && < 0.13,
+    hashable,
     unordered-containers       >= 0.2      && < 0.3,
     thyme                      >= 0.3      && < 0.4,
     old-locale                 >= 1.0      && < 2.0,

--- a/orgmode-parse.cabal
+++ b/orgmode-parse.cabal
@@ -69,7 +69,7 @@ Test-Suite tests
     thyme                      >= 0.3      && < 0.4,
     old-locale                 >= 1.0      && < 2.0,
     HUnit                      >= 1.2.5.2  && < 1.3,
-    tasty                      >= 0.8      && < 0.9,
+    tasty                      >= 0.8      && < 0.11,
     tasty-hunit                >= 0.8.0.1  && < 0.9,
     containers
 

--- a/orgmode-parse.cabal
+++ b/orgmode-parse.cabal
@@ -70,7 +70,8 @@ Test-Suite tests
     old-locale                 >= 1.0      && < 2.0,
     HUnit                      >= 1.2.5.2  && < 1.3,
     tasty                      >= 0.8      && < 0.9,
-    tasty-hunit                >= 0.8.0.1  && < 0.9
+    tasty-hunit                >= 0.8.0.1  && < 0.9,
+    containers
 
 Source-Repository head
   Type:                 git

--- a/orgmode-parse.cabal
+++ b/orgmode-parse.cabal
@@ -43,6 +43,7 @@ Library
                 , bytestring
                 , containers                >= 0.5.5    && < 0.6
                 , free                      >= 4.9      && < 5
+                , hashable                  >= 1.2      && < 1.3
                 , old-locale                >= 1.0      && < 2.0
                 , text                      >= 1.0      && < 2.0
                 , thyme                     >= 0.3      && < 0.4

--- a/src/Data/OrgMode/Parse.hs
+++ b/src/Data/OrgMode/Parse.hs
@@ -1,13 +1,12 @@
------------------------------------------------------------------------------
--- |
--- Module      :  Data.OrgMode.Parse.Attoparsec.Headings
--- Copyright   :  © 2014 Parnell Springmeyer
--- License     :  All Rights Reserved
--- Maintainer  :  Parnell Springmeyer <parnell@digitalmentat.com>
--- Stability   :  stable
---
--- Attoparsec combinators for orgmode documents.
-----------------------------------------------------------------------------
+{-|
+Module      :  Data.OrgMode.Parse.Attoparsec.Headings
+Copyright   :  © 2014 Parnell Springmeyer
+License     :  All Rights Reserved
+Maintainer  :  Parnell Springmeyer <parnell@digitalmentat.com>
+Stability   :  stable
+
+Attoparsec combinators for orgmode documents.
+-}
 
 module Data.OrgMode.Parse (
 

--- a/src/Data/OrgMode/Parse.hs
+++ b/src/Data/OrgMode/Parse.hs
@@ -9,18 +9,35 @@
 -- Attoparsec combinators for orgmode documents.
 ----------------------------------------------------------------------------
 
-module Data.OrgMode.Parse
-(
--- * Parse Document
+module Data.OrgMode.Parse (
 
--- * Parse Headline
-  module Data.OrgMode.Parse.Attoparsec.Headings
--- * Parse Headline Metadata (properties, timestamps, etc...)
-, module Data.OrgMode.Parse.Attoparsec.Time
+-- * Parse OrgMode documents
+  module Data.OrgMode.Parse.Attoparsec.Document
+
+-- * OrgMode Document structure
+, module Data.OrgMode.Parse.Types
+
+-- * Parse headlines
+, module Data.OrgMode.Parse.Attoparsec.Headings
+
+-- * Parse headline metadata sections
+, module Data.OrgMode.Parse.Attoparsec.Section
+
+-- * Parse metadata property drawers
 , module Data.OrgMode.Parse.Attoparsec.PropertyDrawer
--- * Parse Body
+
+-- * Parse metadata timestamps and modifiers
+, module Data.OrgMode.Parse.Attoparsec.Time
 ) where
 
-import           Data.OrgMode.Parse.Attoparsec.Headings
-import           Data.OrgMode.Parse.Attoparsec.PropertyDrawer
-import           Data.OrgMode.Parse.Attoparsec.Time
+import Data.OrgMode.Parse.Attoparsec.Document
+
+import Data.OrgMode.Parse.Attoparsec.Section
+
+import Data.OrgMode.Parse.Attoparsec.Headings
+
+import Data.OrgMode.Parse.Attoparsec.PropertyDrawer
+
+import Data.OrgMode.Parse.Attoparsec.Time
+
+import Data.OrgMode.Parse.Types

--- a/src/Data/OrgMode/Parse/Attoparsec/Document.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Document.hs
@@ -1,0 +1,22 @@
+module Data.OrgMode.Parse.Attoparsec.Document (
+ parseDocument
+) where
+
+import           Control.Applicative                     ((<$>), (<*>))
+import           Data.Attoparsec.Text                    as T
+import           Data.Attoparsec.Types                   as TP
+import           Prelude                                 hiding (unlines)
+import           Data.Text                               (Text, pack, unlines)
+import           Data.OrgMode.Parse.Types
+import           Data.OrgMode.Parse.Attoparsec.Headings
+
+------------------------------------------------------------------------------
+parseDocument :: [Text] -> TP.Parser Text Document
+parseDocument otherKeywords = Document
+                              <$> (unlines <$> many' nonHeaderLine)
+                              <*> many' (headingBelowLevel otherKeywords 0)
+
+nonHeaderLine :: TP.Parser Text Text
+nonHeaderLine = pack <$> manyTill (notChar '*') endOfLine
+
+

--- a/src/Data/OrgMode/Parse/Attoparsec/Headings.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Headings.hs
@@ -105,7 +105,7 @@ takeTitleExtras = do
   s          <- option Nothing (Just <$> parseStats <* skipSpace')
   t          <- option Nothing (Just <$> parseTags  <* skipSpace')
   leftovers  <- option mempty  (takeTill (== '\n'))
-  void endOfLine
+  void (endOfLine <|> endOfInput)
   let titleText
         | null leftovers = strip titleStart
         | otherwise      = append titleStart leftovers

--- a/src/Data/OrgMode/Parse/Attoparsec/Headings.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Headings.hs
@@ -47,7 +47,7 @@ headingBelowLevel otherKeywords levelReq = do
     endOfLine
     sect <- parseSection otherKeywords
     subs <- many' (headingBelowLevel otherKeywords (levelReq + 1))
-    return $ Heading lvl td pr tl s (fromMaybe [] k) undefined subs
+    return $ Heading lvl td pr tl s (fromMaybe [] k) sect subs
 
 
 -- | Parse the asterisk indicated heading level until a space is

--- a/src/Data/OrgMode/Parse/Attoparsec/Headings.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Headings.hs
@@ -10,7 +10,6 @@
 ----------------------------------------------------------------------------
 
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
 
 module Data.OrgMode.Parse.Attoparsec.Headings
 ( headingBelowLevel
@@ -25,11 +24,10 @@ import           Control.Monad            (when, void)
 import           Data.Monoid              (mempty)
 import           Data.Attoparsec.Text     as T
 import           Data.Attoparsec.Types    as TP (Parser)
-import           Data.Char                (isUpper)
 import           Data.Maybe               (fromMaybe)
-import           Data.Text                as Text (Text, append, concat,
-                                                   length, replicate, null, pack)
-import           Prelude                  hiding (concat, null, takeWhile, sequence_)
+import           Data.Text                as Text (Text, append,
+                                                   length, pack, unlines)
+import           Prelude                  hiding (concat, null, takeWhile, sequence_, unlines)
 
 import           Data.OrgMode.Parse.Types
 import Data.OrgMode.Parse.Attoparsec.Time
@@ -46,9 +44,7 @@ headingBelowLevel otherKeywords levelReq = do
              (Just <$> parseTodoKeyword otherKeywords) <* skipSpace
     pr   <- option Nothing (Just <$> headingPriority)  <* skipSpace
     (tl, s, k) <- takeTitleExtras                      <* skipSpace
-
-    --sect <- option emptySection (parseSection otherKeywords) <* skipSpace
-    sect <- parseSection otherKeywords                 <* skipSpace
+    sect <- parseSection
     subs <- option [] $ many' (headingBelowLevel otherKeywords (levelReq + 1))
     skipSpace
     return $ Heading lvl td pr tl s (fromMaybe [] k) sect subs
@@ -77,21 +73,17 @@ headingPriority = start
     start         = string "[#"
     end           = char   ']'
 
-parseSection :: [Text] -> TP.Parser Text Section
-parseSection td = do
+parseSection :: TP.Parser Text Section
+parseSection = do
   clks  <- many' parseClock
   plns  <- parsePlannings
-  props <- option mempty parseDrawer
-  leftovers <- pack <$>
-               manyTill anyChar (void (headingBelowLevel td 0)
-                                 <|> endOfInput
-                                 <|> endOfLine)
-  --void (endOfLine <|> endOfInput)
-  skipSpace
+  props <- option mempty parseDrawer <* skipSpace
+  leftovers <- unlines <$> many' nonHeaderLine
   return (Section (Plns plns) props clks leftovers)
 
-emptySection :: Section
-emptySection = Section (Plns mempty) mempty mempty mempty
+nonHeaderLine :: TP.Parser Text Text
+nonHeaderLine = pack <$> manyTill (notChar '*') endOfLine
+
 
 -- | Parse the state indicator {`TODO` | `DONE` | otherTodoKeywords }.
 --
@@ -113,7 +105,6 @@ takeTitleExtras = do
   leftovers  <- option mempty (takeTill (== '\n'))
   void (char '\n')
   return (append titleStart leftovers, s, t)
-  --return (titleStart, s, t)
 
 parseStats :: TP.Parser Text Stats
 parseStats = sPct <|> sOf
@@ -126,66 +117,3 @@ parseStats = sPct <|> sOf
 parseTags :: TP.Parser Text [Tag]
 parseTags = char ':' *> many1 parseTag
   where parseTag = takeWhile (notInClass "\n\t:") <* char ':'
-
--- -- | Try to parse a title that has keys.
--- --
--- -- This function recurs for every occurrence of ':' and tries to parse
--- -- it as a keyword. If the keyword parser fails we fold the ':' onto
--- -- our title result. If it succeeds then we return the title *and the
--- -- parsed keyword*.
--- takeTitleKeys :: TP.Parser Text (Text, Maybe Keyword)
--- takeTitleKeys = do
---     t  <- takeWhile $ notInClass ":\n\r"
---     cl <- char ':'
---     k  <- headingKeyword'
-
---     if isJust k
---     then char ':' *> return (t, k)
---     else do
---         (t', k') <- takeTitleKeys
---         return (concat [t, pack [cl], t'], k')
-
--- -- | Parse a heading keyword.
--- --
--- -- NOTE: this is meant to be used with `takeTitleKeys` since it cannot
--- -- fail and we use it recursively in that function to determine
--- -- whether we are hitting a keyword chunk or not (and saving it if we
--- -- do!).
--- --
--- -- It is not exported because it is not meant to be used outside of
--- -- the `takeTitleKeys` function.
--- headingKeyword' :: TP.Parser Text (Maybe Keyword)
--- headingKeyword' = do
---     key <- takeWhile $ notInClass " :\n\r"
---     if null key
---     then return Nothing
---     else return . Just $ Keyword key
-
--- -- | Parse a heading keyword.
--- --
--- -- You can use this with `many'` and `catMaybes` to get a list
--- -- keywords:
--- --
--- -- > keys <- many' headingKeyword
--- -- > return $ catMaybes keys
--- headingKeyword :: TP.Parser Text (Maybe Keyword)
--- headingKeyword = do
---     key <- (takeWhile1 $ notInClass ":\n\r") <* char ':'
---     if null key
---     then return Nothing
---     else return . Just $ Keyword key
--- This function tries to parse a title with a keyword and if it fails
--- it then attempts to parse everything till the end of the line.
-
-
--- headingTitle :: TP.Parser Text (Text, Maybe [Tag])
--- headingTitle = takeTitleKeys <|> takeTitleEnd
-
--- takeTitleKeys :: TP.Parser Text (Text, Maybe [Tag])
--- takeTitleKeys = (,) <$> takeTill (== ':') <*> (Just <$> parseTags)
-
--- takeTitleEnd :: TP.Parser Text (Text, Maybe [Tag])
--- takeTitleEnd = do
---     t <- takeTill isEndOfLine
---     return (t, Nothing)
-

--- a/src/Data/OrgMode/Parse/Attoparsec/Headings.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Headings.hs
@@ -47,7 +47,8 @@ headingBelowLevel otherKeywords levelReq = do
     pr   <- option Nothing (Just <$> headingPriority)  <* skipSpace
     (tl, s, k) <- takeTitleExtras                      <* skipSpace
 
-    sect <- option emptySection (parseSection otherKeywords) <* skipSpace
+    --sect <- option emptySection (parseSection otherKeywords) <* skipSpace
+    sect <- parseSection otherKeywords
     subs <- many' (headingBelowLevel otherKeywords (levelReq + 1))
     return $ Heading lvl td pr tl s (fromMaybe [] k) sect subs
 
@@ -77,9 +78,9 @@ headingPriority = start
 
 parseSection :: [Text] -> TP.Parser Text Section
 parseSection td = do
-  plns  <- parsePlannings
-  props <- parseDrawer
   clks  <- many' parseClock
+  plns  <- parsePlannings
+  props <- option mempty parseDrawer
   leftovers <- pack <$>
                manyTill anyChar (void (headingBelowLevel td 0)
                                  <|> endOfInput

--- a/src/Data/OrgMode/Parse/Attoparsec/Headings.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Headings.hs
@@ -29,8 +29,6 @@ import           Data.Text                as Text (Text, append,
 import           Prelude                  hiding (concat, null, takeWhile, sequence_, unlines)
 
 import           Data.OrgMode.Parse.Types
-import Data.OrgMode.Parse.Attoparsec.Time
-import Data.OrgMode.Parse.Attoparsec.PropertyDrawer
 import Data.OrgMode.Parse.Attoparsec.Section
 
 
@@ -74,10 +72,10 @@ headingPriority = start
 takeTitleExtras :: TP.Parser Text (Text, Maybe Stats, Maybe [Tag])
 takeTitleExtras = do
   titleStart <- takeTill (inClass "[:\n")
-  s          <- option Nothing (Just <$> parseStats) <* many' (char ' ')
-  t          <- option Nothing (Just <$> parseTags)  <* many' (char ' ')
+  s          <- option Nothing (Just <$> parseStats) <* skipSpace
+  t          <- option Nothing (Just <$> parseTags)  <* skipSpace
   leftovers  <- option mempty (takeTill (== '\n'))
-  void (char '\n')
+  void endOfLine
   return (append titleStart leftovers, s, t)
 
 parseStats :: TP.Parser Text Stats

--- a/src/Data/OrgMode/Parse/Attoparsec/Headings.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Headings.hs
@@ -33,9 +33,14 @@ import           Data.OrgMode.Parse.Types
 import Data.OrgMode.Parse.Attoparsec.Time
 import Data.OrgMode.Parse.Attoparsec.PropertyDrawer
 
-parseDocument :: [Text] -> TP.Parser Text [Heading] -- Not quit a document yet
-parseDocument otherKeywords = many' (headingBelowLevel otherKeywords 0)
+
+
 ------------------------------------------------------------------------------
+parseDocument :: [Text] -> TP.Parser Text Document
+parseDocument otherKeywords = Document
+                              <$> (unlines <$> many' nonHeaderLine)
+                              <*> many' (headingBelowLevel otherKeywords 0)
+
 -- | Parse an org-mode heading.
 headingBelowLevel :: [Text] -> Int -> TP.Parser Text Heading
 headingBelowLevel otherKeywords levelReq = do

--- a/src/Data/OrgMode/Parse/Attoparsec/Headings.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Headings.hs
@@ -48,8 +48,9 @@ headingBelowLevel otherKeywords levelReq = do
     (tl, s, k) <- takeTitleExtras                      <* skipSpace
 
     --sect <- option emptySection (parseSection otherKeywords) <* skipSpace
-    sect <- parseSection otherKeywords
-    subs <- many' (headingBelowLevel otherKeywords (levelReq + 1))
+    sect <- parseSection otherKeywords                 <* skipSpace
+    subs <- option [] $ many' (headingBelowLevel otherKeywords (levelReq + 1))
+    skipSpace
     return $ Heading lvl td pr tl s (fromMaybe [] k) sect subs
 
 
@@ -86,6 +87,7 @@ parseSection td = do
                                  <|> endOfInput
                                  <|> endOfLine)
   --void (endOfLine <|> endOfInput)
+  skipSpace
   return (Section (Plns plns) props clks leftovers)
 
 emptySection :: Section

--- a/src/Data/OrgMode/Parse/Attoparsec/Headings.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Headings.hs
@@ -13,132 +13,163 @@
 {-# LANGUAGE TemplateHaskell   #-}
 
 module Data.OrgMode.Parse.Attoparsec.Headings
-( heading
+( headingBelowLevel
 , headingLevel
 , headingPriority
 , headingTitle
-, headingKeyword
 )
 where
 
-import           Control.Applicative      ((*>), (<*), (<|>))
+import           Control.Applicative      ((*>), (<*), (<|>),(<$>), pure, (<*>))
+import           Control.Monad            (when)
 import           Data.Attoparsec.Text     as T
 import           Data.Attoparsec.Types    as TP (Parser)
 import           Data.Char                (isUpper)
-import           Data.Maybe               (catMaybes, isJust)
-import           Data.Text                as Text (Text, concat, length, null,
-                                                   pack)
-import           Prelude                  hiding (concat, null, takeWhile)
+import           Data.Maybe               (fromMaybe)
+import           Data.Text                as Text (Text, append, concat,
+                                                   length, replicate, null, pack)
+import           Prelude                  hiding (concat, null, takeWhile, sequence_)
 
 import           Data.OrgMode.Parse.Types
+import Data.OrgMode.Parse.Attoparsec.Time
+import Data.OrgMode.Parse.Attoparsec.PropertyDrawer
 
+
+------------------------------------------------------------------------------
 -- | Parse an org-mode heading.
-heading :: TP.Parser Text Heading
-heading = do
-    lvl  <- headingLevel
-    st   <- option Nothing headingState
-    pr   <- option Nothing headingPriority
-
-    (tl, k) <- headingTitle
-
-    keys <- attemptKeys k
-
+headingBelowLevel :: [Text] -> Int -> TP.Parser Text Heading
+headingBelowLevel otherKeywords levelReq = do
+    lvl  <- headingLevel levelReq                      <* skipSpace
+    td   <- option Nothing
+             (Just <$> parseTodoKeyword otherKeywords) <* skipSpace
+    pr   <- option Nothing (Just <$> headingPriority)  <* skipSpace
+    (tl, s, k) <- takeTitleExtras
     endOfLine
+    sect <- parseSection otherKeywords
+    subs <- many' (headingBelowLevel otherKeywords (levelReq + 1))
+    return $ Heading lvl td pr tl s (fromMaybe [] k) undefined subs
 
-    return $ Heading lvl pr st tl (catMaybes (k:keys))
-
-  where
-    attemptKeys (Just _) = many' (headingKeyword)
-    attemptKeys Nothing  = return []
 
 -- | Parse the asterisk indicated heading level until a space is
 -- reached.
-headingLevel :: TP.Parser Text Int
-headingLevel = return . Text.length =<< takeWhile1 (== '*')
+headingLevel :: Int -> TP.Parser Text Int
+headingLevel levelReq = do
+  stars <- takeWhile1 (== '*')
+  let lvl = Text.length stars
+  when (lvl < levelReq) (fail "Heading level too high")
+  return lvl
 
 -- | Parse the priority indicator.
 --
 -- If anything but these priority indicators are used the parser will
 -- fail: `[#A]`, `[#B]`, `[#C]`.
-headingPriority :: TP.Parser Text (Maybe Priority)
-headingPriority = do
-    pr <- start *> (takeWhile $ inClass "ABC") <* end
-    if null pr
-    then fail "Priority must be one of [#A], [#B], or [#C]"
-    else return . Just $ toPriority pr
+headingPriority :: TP.Parser Text Priority
+headingPriority = start
+                  *> choice (zipWith mkPParser "ABC" [A,B,C])
+                  <* end
   where
-    start = char '[' *> char '#'
-    end   = char ']' <* space
+    mkPParser c p = char c *> pure p
+    start         = string "[#"
+    end           = char   ']'
 
+parseSection :: [Text] -> TP.Parser Text Section
+parseSection td = do
+  plns  <- parsePlannings
+  props <- parseDrawer
+  clks  <- many' parseClock
+  leftovers <- pack <$>
+               manyTill anyChar (headingBelowLevel td 0)
+  return (Section plns props clks leftovers)
 
--- | Parse the state indicator {`TODO` | `DOING` | `DONE`}.
+-- | Parse the state indicator {`TODO` | `DONE` | otherTodoKeywords }.
 --
--- These can be custom so we're parsing the state identifier as Text
--- but wrapped with the State newtype.
-headingState :: TP.Parser Text (Maybe State)
-headingState = do
-    st <- space *> takeWhile isUpper <* space
+-- These can be custom so we're parsing additional state
+-- identifiers as Text
+parseTodoKeyword :: [Text] -> TP.Parser Text TodoKeyword
+parseTodoKeyword otherKeywords =
+    choice ([string "TODO" *> pure TODO
+            ,string "DONE" *> pure DONE
+            ] ++
+            map (\k -> OtherKeyword <$> string k) otherKeywords)
 
-    if null st
-    then return Nothing
-    else return . Just $ State st
 
--- | Title parser with alternative.
---
 -- This function tries to parse a title with a keyword and if it fails
 -- it then attempts to parse everything till the end of the line.
-headingTitle :: TP.Parser Text (Text, Maybe Keyword)
+headingTitle :: TP.Parser Text (Text, Maybe [Tag])
 headingTitle = takeTitleKeys <|> takeTitleEnd
 
-takeTitleEnd :: TP.Parser Text (Text, Maybe Keyword)
+takeTitleKeys :: TP.Parser Text (Text, Maybe [Tag])
+takeTitleKeys = (,) <$> takeTill (== ':') <*> (Just <$> parseTags)
+
+takeTitleExtras :: TP.Parser Text (Text, Maybe Stats, Maybe [Tag])
+takeTitleExtras = do
+  titleStart <- takeTill (inClass "[:")
+  stats      <- option Nothing (Just <$> parseStats)
+  tags       <- option Nothing (Just <$> parseTags)
+  leftovers  <- takeTill (== '\n')
+  return (append titleStart leftovers, stats, tags)
+
+takeTitleEnd :: TP.Parser Text (Text, Maybe [Tag])
 takeTitleEnd = do
     t <- takeTill isEndOfLine
     return (t, Nothing)
 
--- | Try to parse a title that may have keys.
---
--- This function recurs for every occurrence of ':' and tries to parse
--- it as a keyword. If the keyword parser fails we fold the ':' onto
--- our title result. If it succeeds then we return the title *and the
--- parsed keyword*.
-takeTitleKeys :: TP.Parser Text (Text, Maybe Keyword)
-takeTitleKeys = do
-    t  <- takeWhile $ notInClass ":\n\r"
-    cl <- char ':'
-    k  <- headingKeyword'
+parseStats :: TP.Parser Text Stats
+parseStats = sPct <|> sOf
+  where sPct = StatsPct
+               <$> (char '[' *> decimal <* string "%]")
+        sOf  = StatsOf
+               <$> (char '[' *> decimal)
+               <*> (char '/' *> decimal <* char ']')
 
-    if isJust k
-    then char ':' *> return (t, k)
-    else do
-        (t', k') <- takeTitleKeys
-        return (concat [t, pack [cl], t'], k')
+parseTags :: TP.Parser Text [Tag]
+parseTags = char ':' *> many1 parseTag
+  where parseTag = takeWhile (notInClass "\n\t:") <* char ':'
 
--- | Parse a heading keyword.
---
--- NOTE: this is meant to be used with `takeTitleKeys` since it cannot
--- fail and we use it recursively in that function to determine
--- whether we are hitting a keyword chunk or not (and saving it if we
--- do!).
---
--- It is not exported because it is not meant to be used outside of
--- the `takeTitleKeys` function.
-headingKeyword' :: TP.Parser Text (Maybe Keyword)
-headingKeyword' = do
-    key <- takeWhile $ notInClass " :\n\r"
-    if null key
-    then return Nothing
-    else return . Just $ Keyword key
+-- -- | Try to parse a title that has keys.
+-- --
+-- -- This function recurs for every occurrence of ':' and tries to parse
+-- -- it as a keyword. If the keyword parser fails we fold the ':' onto
+-- -- our title result. If it succeeds then we return the title *and the
+-- -- parsed keyword*.
+-- takeTitleKeys :: TP.Parser Text (Text, Maybe Keyword)
+-- takeTitleKeys = do
+--     t  <- takeWhile $ notInClass ":\n\r"
+--     cl <- char ':'
+--     k  <- headingKeyword'
 
--- | Parse a heading keyword.
---
--- You can use this with `many'` and `catMaybes` to get a list
--- keywords:
---
--- > keys <- many' headingKeyword
--- > return $ catMaybes keys
-headingKeyword :: TP.Parser Text (Maybe Keyword)
-headingKeyword = do
-    key <- (takeWhile1 $ notInClass ":\n\r") <* char ':'
-    if null key
-    then return Nothing
-    else return . Just $ Keyword key
+--     if isJust k
+--     then char ':' *> return (t, k)
+--     else do
+--         (t', k') <- takeTitleKeys
+--         return (concat [t, pack [cl], t'], k')
+
+-- -- | Parse a heading keyword.
+-- --
+-- -- NOTE: this is meant to be used with `takeTitleKeys` since it cannot
+-- -- fail and we use it recursively in that function to determine
+-- -- whether we are hitting a keyword chunk or not (and saving it if we
+-- -- do!).
+-- --
+-- -- It is not exported because it is not meant to be used outside of
+-- -- the `takeTitleKeys` function.
+-- headingKeyword' :: TP.Parser Text (Maybe Keyword)
+-- headingKeyword' = do
+--     key <- takeWhile $ notInClass " :\n\r"
+--     if null key
+--     then return Nothing
+--     else return . Just $ Keyword key
+
+-- -- | Parse a heading keyword.
+-- --
+-- -- You can use this with `many'` and `catMaybes` to get a list
+-- -- keywords:
+-- --
+-- -- > keys <- many' headingKeyword
+-- -- > return $ catMaybes keys
+-- headingKeyword :: TP.Parser Text (Maybe Keyword)
+-- headingKeyword = do
+--     key <- (takeWhile1 $ notInClass ":\n\r") <* char ':'
+--     if null key
+--     then return Nothing
+--     else return . Just $ Keyword key

--- a/src/Data/OrgMode/Parse/Attoparsec/Headings.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Headings.hs
@@ -16,6 +16,7 @@ module Data.OrgMode.Parse.Attoparsec.Headings
 , headingLevel
 , headingPriority
 , parseStats
+, parseTags
 )
 where
 
@@ -25,7 +26,7 @@ import           Data.Monoid              (mempty)
 import           Data.Attoparsec.Text     as T
 import           Data.Attoparsec.Types    as TP (Parser)
 import           Data.Maybe               (fromMaybe)
-import           Data.Text                as Text (Text, append, length, null, pack, strip)
+import           Data.Text                as Text (Text, append, init, last, length, null, pack, splitOn, strip, tail)
 import           Prelude                  hiding (concat, null, takeWhile, sequence_, unlines)
 
 import           Data.OrgMode.Parse.Types
@@ -127,8 +128,12 @@ parseStats = sPct <|> sOf
 --
 -- e.g. :HOMEWORK:POETRY:WRITING:
 parseTags :: TP.Parser Text [Tag]
-parseTags = map pack <$>
-             (char ':' *> (many' anyChar `sepBy` char ':') <* char ':')
+parseTags = do
+  tagsStr <-  (char ':' *> takeWhile (/= '\n'))
+  when (Text.last tagsStr /= ':' || Text.length tagsStr < 2) (fail "Not a valid tags set")
+  return (splitOn ":" (Text.init  $ tagsStr))
+
+--             (char ':' *> ((takeWhile (\c -> c /= ':' && c /= '\n')) `sepBy` char ':') <* char ':')
 
 skipSpace' :: TP.Parser Text ()
 skipSpace' = void (takeWhile (inClass " \t"))

--- a/src/Data/OrgMode/Parse/Attoparsec/PropertyDrawer.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/PropertyDrawer.hs
@@ -18,11 +18,11 @@ module Data.OrgMode.Parse.Attoparsec.PropertyDrawer
 )
 where
 
-import           Control.Applicative      ((*>), (<*))
+import           Control.Applicative      ((*>), (<*), (<*>),(<*>),pure)
 import           Data.Attoparsec.Text     as T
-import           Data.Attoparsec.Types    as TP (Parser)
+import           Data.Attoparsec.Types    as TP
 import           Data.HashMap.Strict      (fromList)
-import           Data.Text                as Text (Text, strip)
+import           Data.Text                as Text (Text, strip, pack, unpack)
 import           Prelude                  hiding (concat, null, takeWhile)
 
 import           Data.OrgMode.Parse.Types

--- a/src/Data/OrgMode/Parse/Attoparsec/PropertyDrawer.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/PropertyDrawer.hs
@@ -10,7 +10,6 @@
 ----------------------------------------------------------------------------
 
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
 
 module Data.OrgMode.Parse.Attoparsec.PropertyDrawer
 ( parseDrawer
@@ -18,11 +17,11 @@ module Data.OrgMode.Parse.Attoparsec.PropertyDrawer
 )
 where
 
-import           Control.Applicative      ((*>), (<*), (<*>),(<*>),pure)
+import           Control.Applicative      ((*>), (<*))
 import           Data.Attoparsec.Text     as T
 import           Data.Attoparsec.Types    as TP
-import           Data.HashMap.Strict      (HashMap(..),fromList)
-import           Data.Text                as Text (Text, strip, pack, unpack)
+import           Data.HashMap.Strict      (fromList)
+import           Data.Text                as Text (Text, strip)
 import           Prelude                  hiding (concat, null, takeWhile)
 
 import           Data.OrgMode.Parse.Types
@@ -33,7 +32,7 @@ import           Data.OrgMode.Parse.Types
 -- > :DATE: [2014-12-14 11:00]
 -- > :NOTE: Something really crazy happened today!
 -- > :END:
-parseDrawer :: TP.Parser Text (HashMap Text Text)
+parseDrawer :: TP.Parser Text Properties
 parseDrawer = do
     props <- begin *> manyTill property end
     return $ fromList props

--- a/src/Data/OrgMode/Parse/Attoparsec/PropertyDrawer.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/PropertyDrawer.hs
@@ -13,7 +13,7 @@
 {-# LANGUAGE TemplateHaskell   #-}
 
 module Data.OrgMode.Parse.Attoparsec.PropertyDrawer
-( drawer
+( parseDrawer
 , property
 )
 where
@@ -21,7 +21,7 @@ where
 import           Control.Applicative      ((*>), (<*), (<*>),(<*>),pure)
 import           Data.Attoparsec.Text     as T
 import           Data.Attoparsec.Types    as TP
-import           Data.HashMap.Strict      (fromList)
+import           Data.HashMap.Strict      (HashMap(..),fromList)
 import           Data.Text                as Text (Text, strip, pack, unpack)
 import           Prelude                  hiding (concat, null, takeWhile)
 
@@ -33,10 +33,10 @@ import           Data.OrgMode.Parse.Types
 -- > :DATE: [2014-12-14 11:00]
 -- > :NOTE: Something really crazy happened today!
 -- > :END:
-drawer :: TP.Parser Text (PropertyDrawer Text Text)
-drawer = do
+parseDrawer :: TP.Parser Text (HashMap Text Text)
+parseDrawer = do
     props <- begin *> manyTill property end
-    return . PropertyDrawer $ fromList props
+    return $ fromList props
   where
     begin   = ident "PROPERTIES"
     end     = ident "END"

--- a/src/Data/OrgMode/Parse/Attoparsec/Section.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Section.hs
@@ -2,7 +2,7 @@
 
 module Data.OrgMode.Parse.Attoparsec.Section where
 
-import           Control.Applicative                     ((<$>), (<*), (*>), pure)
+import           Control.Applicative                     ((<$>), (<*))
 import           Data.Attoparsec.Text                    as T
 import           Data.Attoparsec.Types                   as TP
 import           Data.Monoid                             (mempty)
@@ -20,18 +20,6 @@ parseSection = do
   props <- option mempty parseDrawer <* skipSpace
   leftovers <- unlines <$> many' nonHeaderLine
   return (Section (Plns plns) props clks leftovers)
-
-
--- | Parse the state indicator {`TODO` | `DONE` | otherTodoKeywords }.
---
--- These can be custom so we're parsing additional state
--- identifiers as Text
-parseTodoKeyword :: [Text] -> TP.Parser Text TodoKeyword
-parseTodoKeyword otherKeywords =
-    choice ([string "TODO" *> pure TODO
-            ,string "DONE" *> pure DONE
-            ] ++
-            map (\k -> OtherKeyword <$> string k) otherKeywords)
 
 
 nonHeaderLine :: TP.Parser Text Text

--- a/src/Data/OrgMode/Parse/Attoparsec/Section.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Section.hs
@@ -2,7 +2,7 @@
 
 module Data.OrgMode.Parse.Attoparsec.Section where
 
-import           Control.Applicative                     ((<$>), (<*))
+import           Control.Applicative                     ((<$>), (<*), (<*>))
 import           Data.Attoparsec.Text                    as T
 import           Data.Attoparsec.Types                   as TP
 import           Data.Monoid                             (mempty)
@@ -13,15 +13,17 @@ import           Data.OrgMode.Parse.Attoparsec.Time
 import           Data.OrgMode.Parse.Attoparsec.PropertyDrawer
 
 
+-- | Parse a heading section
+--
+-- Heading sections contain optionally a property drawer,
+-- a list of clock entries, code blocks (not yet implemented),
+-- plain lists (not yet implemented), and unstructured text.
 parseSection :: TP.Parser Text Section
-parseSection = do
-  clks  <- many' parseClock
-  plns  <- parsePlannings
-  props <- option mempty parseDrawer <* skipSpace
-  leftovers <- unlines <$> many' nonHeaderLine
-  return (Section (Plns plns) props clks leftovers)
-
-
-nonHeaderLine :: TP.Parser Text Text
-nonHeaderLine = pack <$> manyTill (notChar '*') endOfLine
+parseSection = Section
+               <$> (Plns <$> parsePlannings)
+               <*> option mempty parseDrawer <* skipSpace
+               <*> many' parseClock
+               <*> (unlines <$> many' nonHeaderLine)
+  where
+    nonHeaderLine = pack <$> manyTill (notChar '*') endOfLine
 

--- a/src/Data/OrgMode/Parse/Attoparsec/Section.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Section.hs
@@ -2,7 +2,7 @@
 
 module Data.OrgMode.Parse.Attoparsec.Section where
 
-import           Control.Applicative                     ((<$>), (<*), (<*>))
+import           Control.Applicative                     ((<$>), (<*>))
 import           Data.Attoparsec.Text                    as T
 import           Data.Attoparsec.Types                   as TP
 import           Data.Monoid                             (mempty)
@@ -21,9 +21,8 @@ import           Data.OrgMode.Parse.Attoparsec.PropertyDrawer
 parseSection :: TP.Parser Text Section
 parseSection = Section
                <$> (Plns <$> parsePlannings)
-               <*> option mempty parseDrawer <* skipSpace
                <*> many' parseClock
+               <*> option mempty parseDrawer
                <*> (unlines <$> many' nonHeaderLine)
   where
     nonHeaderLine = pack <$> manyTill (notChar '*') endOfLine
-

--- a/src/Data/OrgMode/Parse/Attoparsec/Section.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Section.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Data.OrgMode.Parse.Attoparsec.Section where
+
+import           Control.Applicative                     ((<$>), (<*), (*>), pure)
+import           Data.Attoparsec.Text                    as T
+import           Data.Attoparsec.Types                   as TP
+import           Data.Monoid                             (mempty)
+import           Prelude                                 hiding (unlines)
+import           Data.Text                               (Text, pack, unlines)
+import           Data.OrgMode.Parse.Types
+import           Data.OrgMode.Parse.Attoparsec.Time
+import           Data.OrgMode.Parse.Attoparsec.PropertyDrawer
+
+
+parseSection :: TP.Parser Text Section
+parseSection = do
+  clks  <- many' parseClock
+  plns  <- parsePlannings
+  props <- option mempty parseDrawer <* skipSpace
+  leftovers <- unlines <$> many' nonHeaderLine
+  return (Section (Plns plns) props clks leftovers)
+
+
+-- | Parse the state indicator {`TODO` | `DONE` | otherTodoKeywords }.
+--
+-- These can be custom so we're parsing additional state
+-- identifiers as Text
+parseTodoKeyword :: [Text] -> TP.Parser Text TodoKeyword
+parseTodoKeyword otherKeywords =
+    choice ([string "TODO" *> pure TODO
+            ,string "DONE" *> pure DONE
+            ] ++
+            map (\k -> OtherKeyword <$> string k) otherKeywords)
+
+
+nonHeaderLine :: TP.Parser Text Text
+nonHeaderLine = pack <$> manyTill (notChar '*') endOfLine
+

--- a/src/Data/OrgMode/Parse/Attoparsec/Time.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Time.hs
@@ -12,20 +12,19 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
 
-module Data.OrgMode.Parse.Attoparsec.Time
-( parseTimestampLine
-, scheduleType
-)
-where
+module Data.OrgMode.Parse.Attoparsec.Time where
 
 import           Control.Applicative        ((<*>), (*>), (<$>), (<*), (<|>), pure)
+import           Control.Monad              (when)
 import qualified Data.Attoparsec.ByteString as AB
 import           Data.Attoparsec.Text       as T
 import           Data.Attoparsec.Types      as TP (Parser)
-import           Data.Maybe                 (isJust)
+import qualified Data.ByteString.Char8      as BS
+import           Data.Maybe                 (listToMaybe, fromJust, isJust)
 import           Data.Text                  as Text (Text, isPrefixOf, unwords,
-                                                     words)
+                                                     pack, unpack, words)
 import           Data.Text.Encoding         (encodeUtf8)
+import           Data.Thyme.Calendar        (YearMonthDay(..))
 import           Data.Thyme.Format          (buildTime, timeParser)
 import           Data.Thyme.LocalTime       (Hours, Minutes)
 import           Prelude                    hiding (concat, null, takeWhile,
@@ -34,25 +33,84 @@ import           System.Locale              (defaultTimeLocale)
 
 import           Data.OrgMode.Parse.Types
 
--- | Parse diary line
-parseDiary :: TP.Parser Text Timestamp
-parseDiary = string "<%%" *> manyTill (char '>') (try (char '>'))
+parseTimestamp :: TP.Parser Text Timestamp
+parseTimestamp = do
+  (ts1,ts1b,active1) <- parseBracketedDateTime
+  t2 <- option Nothing (Just <$> (string "--" *> parseBracketedDateTime))
+  case (ts1b,t2) of
+    (Nothing,      Nothing) ->
+       return (Timestamp ts1 active1 Nothing)
+    (Nothing, Just (ts2,Nothing,_)) ->
+      return  (Timestamp ts1 active1 (Just ts2))
+    (Nothing, Just _) ->
+      fail "Illegal time range in second timerange timestamp"
+    (Just (h',m'), Nothing) ->
+      return (Timestamp ts1 active1
+               (Just $ ts1 {hourMinute = Just (h',m')
+                           ,repeater   = Nothing
+                           ,delay      = Nothing}))
+    (Just _, Just _) -> fail "Illegal mix of time range and timestamp range"
 
-parseShortTimeRange :: TP.Parser Text ((Hours,Minutes),(Hours,Minutes))
-parseShortTimeRange = (,) <$> parseHoursMinutes <* char '-' *> parseHoursMinutes
+-- Parse a single time part
+-- returning:
+--   * The basic timestamp
+--   * Whether there was a time interval in place of a single time
+--       (this will be handled upstream by parseTimestamp)
+--   * Whether the time is active or inactive
+parseBracketedDateTime :: TP.Parser Text (DateTime, Maybe (Hours,Minutes), Bool)
+parseBracketedDateTime = do
+  oBracket <- char '<' <|> char '['
+  datePart <- parseDate                            <* skipSpace
+  dName    <- option Nothing (Just <$> parseDay)   <* skipSpace
+  timePart <- option Nothing (Just <$> parseTime') <* skipSpace
+  repPart  <- listToMaybe <$> many' parseRepeater  <* skipSpace
+  delPart  <- listToMaybe <$> many' parseDelay     <* skipSpace
+  cBracket <- char '>' <|> char ']'
 
-parseHoursMinutes :: TP.Parser Text (Hours,Minutes)
-parseHoursMinutes = (,) <$> decimal <* char ':' *> decimal
+  when (complementaryBracket oBracket /= cBracket)
+    (fail "Bad timestamp parse, mismatched brackets")
 
-parseRepeaterType :: TP.Parser Text RepeaterType
-parseRepeaterType = choice 
+  case timePart of
+    Just (Left (h,m)) ->
+      return ( DateTime datePart dName (Just (h,m)) repPart delPart
+             , Nothing
+             , activeBracket '<')
+    Just (Right (t1,t2)) ->
+      return ( DateTime datePart dName (Just t1)repPart delPart
+             , Just t2
+             , activeBracket '<')
+
+    where activeBracket = (=='<')
+          complementaryBracket '<' = '>'
+          complementaryBracket '[' = ']'
+          complementaryBracket x   = x
+
+parseDay :: TP.Parser Text Text
+parseDay = choice (map string ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"])
+
+parseTime' :: TP.Parser Text (Either (Hours,Minutes) ((Hours,Minutes),(Hours,Minutes)))
+parseTime' = choice [Right <$> ((,) <$> parseHM <* char '-' <*> parseHM)
+                    ,Left  <$> parseHM ]
+
+
+parseDate :: TP.Parser Text YearMonthDay
+parseDate = manyTill anyChar (char ' ') >>= \dStr ->
+  case AB.parseOnly dParser (BS.pack dStr) of
+    Left e      -> fail .unpack $
+                   unwords ["No time parse for: ", pack dStr, " Message:", pack e]
+    Right lTime -> return (buildTime lTime)
+  where dParser = timeParser defaultTimeLocale "%Y-%m-%d"
+
+
+parseHM :: TP.Parser Text (Hours,Minutes)
+parseHM = (,) <$> decimal <* char ':' <*> decimal
 
 parseTimeUnit :: TP.Parser Text TimeUnit
-parseTimeUnit = choice [char 'h' *> UnitHour
-                       ,char 'd' *> UnitDay
-                       ,char 'w' *> UnitWeek
-                       ,char 'm' *> UnitMonth
-                       ,char 'y' *> UnitYear]
+parseTimeUnit = choice [char 'h' *> pure UnitHour
+                       ,char 'd' *> pure UnitDay
+                       ,char 'w' *> pure UnitWeek
+                       ,char 'm' *> pure UnitMonth
+                       ,char 'y' *> pure UnitYear]
 
 parseRepeater :: TP.Parser Text Repeater
 parseRepeater = Repeater
@@ -71,24 +129,24 @@ parseDelay = Delay
              <*> decimal
              <*> parseTimeUnit
 
--- | Parse org-mode Timestamps
-parseTimestamp :: TP.Parsere Text Timestamp
--- | Parse an org-mode timestamp (eg "[2015-03-21 Sat 09:45]") with
--- user-supplied opening and ending brackets
-parseTimestamp :: Open -> Close -> TP.Parser Text Timestamp
-parseTimestamp (Open s) (Close e) = activeState <$>
-  char s *>
-  (timeParser1 <|> timeParser2)
-  <* AB.many' (skipSpace *> parseRecur)
-  <* char e
-  where
-    activeState = if s == '<' && e == '>'
-                  then Active else Inactive
-    timeParser1 = timeParser defaultTimeLocale "%Y-%m-%d %a %H:%M"
-    timeParser2 = timeParser defaultTimeLocale "%Y-%m-%d %a"
---      dropRecur   = unwords . filter (not . isPrefixOf "+") . words
-    parseRecur  = char "+" *> AB.many' (digit <|> oneOf "ymdwhm") -- TODO
-    oneOf xs    = AB.choice (map char xs)
+-- -- | Parse org-mode Timestamps
+-- parseTimestamp :: TP.Parsere Text Timestamp
+-- -- | Parse an org-mode timestamp (eg "[2015-03-21 Sat 09:45]") with
+-- -- user-supplied opening and ending brackets
+-- parseTimestamp :: Open -> Close -> TP.Parser Text Timestamp
+-- parseTimestamp (Open s) (Close e) = activeState <$>
+--   char s *>
+--   (timeParser1 <|> timeParser2)
+--   <* AB.many' (skipSpace *> parseRecur)
+--   <* char e
+--   where
+--     activeState = if s == '<' && e == '>'
+--                   then Active else Inactive
+--     timeParser1 = timeParser defaultTimeLocale "%Y-%m-%d %a %H:%M"
+--     timeParser2 = timeParser defaultTimeLocale "%Y-%m-%d %a"
+-- --      dropRecur   = unwords . filter (not . isPrefixOf "+") . words
+--     parseRecur  = char "+" *> AB.many' (digit <|> oneOf "ymdwhm") -- TODO
+--     oneOf xs    = AB.choice (map char xs)
 
 -- | Parse an org-mode timestamp line with user-supplied opening and
 -- ending brackets (for either active or inactive stamps).
@@ -99,9 +157,9 @@ parseTimestampLine (Open s) (Close e) = do
 
     let parts  = words stamp
         r      = if recur parts then Just $ last parts else Nothing
-        parsed = parseStamp parts
-        stamp' = if s == '<' then Active <$> parsed else Inactive <$> parsed
-        sched  = Schedule s' stamp' r
+        parsed = undefined
+        stamp' = undefined -- Drop code refering to old Schedule structure, allow to compile
+        sched  = undefined -- ^
 
     if isJust $ timestamp sched
     then return $ Just sched

--- a/src/Data/OrgMode/Parse/Attoparsec/Time.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Time.hs
@@ -14,7 +14,8 @@
 
 module Data.OrgMode.Parse.Attoparsec.Time where
 
-import           Control.Applicative        ((<*>), (*>), (<$>), (<*), (<|>), pure)
+import           Control.Applicative        ((<*>), (*>), (<$>), (<*),
+                                             (<|>), pure)
 import           Control.Monad              (when)
 import qualified Data.Attoparsec.ByteString as AB
 import           Data.Attoparsec.Text       as T
@@ -26,13 +27,18 @@ import           Data.Text                  as Text (Text, unwords,
                                                      pack, unpack )
 import           Data.Thyme.Format          (buildTime, timeParser)
 import           Data.Thyme.LocalTime       (Hours, Minutes)
-import           Prelude                    hiding (concat, null, takeWhile,
-                                             unwords, words)
+import           Prelude                    hiding (concat, null,
+                                                    takeWhile,
+                                                    unwords, words)
 import           System.Locale              (defaultTimeLocale)
 
 import           Data.OrgMode.Parse.Types
 
-
+-- | Parse a planning line
+--
+-- Plannings live in a heading section and are formatted as a keyword and a timestamp
+-- There can be more than one, but they are all on the same line
+-- e.g. DEADLINE: <2015-05-10 17:00> CLOSED: <2015-04-16 12:00>
 parsePlannings :: TP.Parser Text (HashMap PlanningKeyword Timestamp)
 parsePlannings = fromList <$> (many' (planning <* skipSpace))
   where planning :: TP.Parser Text (PlanningKeyword, Timestamp)
@@ -42,12 +48,26 @@ parsePlannings = fromList <$> (many' (planning <* skipSpace))
                           ,string "CLOSED"    *> pure CLOSED
                           ]
 
+-- | Parse a clock line
+--
+-- A heading's section contains one line per clock entry
+-- Clocks may have a timestamp, a duration, both, or neither
+-- e.g.: CLOCK: [2014-12-10 Fri 2:30]--[2014-12-10 FRI 10:30]  => 08:00
 parseClock :: TP.Parser Text (Maybe Timestamp, Maybe Duration)
 parseClock = (,) <$> (skipSpace *> string "CLOCK: " *> ts) <*> dur
   where ts  = option Nothing (Just <$> parseTimestamp)
         dur = option Nothing (Just <$> (string " => "
                               *> skipSpace *> parseHM))
 
+-- | Parse a timestamp
+--
+-- Timestamps may be timepoints or timeranges, and they indicate
+-- whether they are active or closed by using angle or square brackets respectively
+--
+-- Time ranges are formatted by appending two timepoints with '--' in between,
+--   or by appending two hh:mm stamps together in a single timepoint with a single '-'
+--
+-- Each timepoint includes an optional repeater flag and an optional delay flag
 parseTimestamp :: TP.Parser Text Timestamp
 parseTimestamp = do
   (ts1,ts1b,active1) <- parseBracketedDateTime
@@ -66,7 +86,10 @@ parseTimestamp = do
                            ,delay      = Nothing}))
     (Just _, Just _) -> fail "Illegal mix of time range and timestamp range"
 
--- Parse a single time part
+
+-- | Parse a single time part
+--
+-- e.g. [2015-03-27 Fri 10:20 +4h]
 -- returning:
 --   * The basic timestamp
 --   * Whether there was a time interval in place of a single time
@@ -74,24 +97,24 @@ parseTimestamp = do
 --   * Whether the time is active or inactive
 parseBracketedDateTime :: TP.Parser Text (DateTime, Maybe (Hours,Minutes), Bool)
 parseBracketedDateTime = do
-  oBracket <- char '<' <|> char '['
-  datePart <- parseDate                            <* skipSpace
-  dName    <- option Nothing (Just <$> parseDay)   <* skipSpace
-  timePart <- option Nothing (Just <$> parseTime') <* skipSpace
-  repPart  <- listToMaybe <$> many' parseRepeater  <* skipSpace
-  delPart  <- listToMaybe <$> many' parseDelay     <* skipSpace
-  cBracket <- char '>' <|> char ']'
+  oBracket   <- char '<' <|> char '['
+  datePart   <- parseDate                            <* skipSpace
+  dName      <- option Nothing (Just <$> parseDay)   <* skipSpace
+  timePart   <- option Nothing (Just <$> parseTime') <* skipSpace
+  repeatPart <- listToMaybe <$> many' parseRepeater  <* skipSpace
+  delayPart  <- listToMaybe <$> many' parseDelay     <* skipSpace
+  cBracket   <- char '>' <|> char ']'
 
   when (complementaryBracket oBracket /= cBracket)
     (fail "Bad timestamp parse, mismatched brackets")
 
   case timePart of
     Just (Left (h,m)) ->
-      return ( DateTime (YMD' datePart) dName (Just (h,m)) repPart delPart
+      return ( DateTime (YMD' datePart) dName (Just (h,m)) repeatPart delayPart
              , Nothing
              , activeBracket '<')
     Just (Right (t1,t2)) ->
-      return ( DateTime (YMD' datePart) dName (Just t1)repPart delPart
+      return ( DateTime (YMD' datePart) dName (Just t1)repeatPart delayPart
              , Just t2
              , activeBracket '<')
     Nothing -> fail "Failed to parse a timestamp (HH:MM)"
@@ -101,14 +124,17 @@ parseBracketedDateTime = do
           complementaryBracket '[' = ']'
           complementaryBracket x   = x
 
+-- | Parse a 3-character day name
 parseDay :: TP.Parser Text Text
 parseDay = choice (map string ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"])
 
+-- | Parse the time-of-day part of a time part, as a single point or a time range
 parseTime' :: TP.Parser Text (Either (Hours,Minutes) ((Hours,Minutes),(Hours,Minutes)))
 parseTime' = choice [Right <$> ((,) <$> parseHM <* char '-' <*> parseHM)
                     ,Left  <$> parseHM ]
 
 
+-- | Parse the YYYY-MM-DD part of a time part
 parseDate :: TP.Parser Text YearMonthDay
 parseDate = manyTill anyChar (char ' ') >>= \dStr ->
   case AB.parseOnly dParser (BS.pack dStr) of
@@ -117,10 +143,11 @@ parseDate = manyTill anyChar (char ' ') >>= \dStr ->
     Right lTime -> return (buildTime lTime)
   where dParser = timeParser defaultTimeLocale "%Y-%m-%d"
 
-
+-- | Parse a single HH:MM point
 parseHM :: TP.Parser Text (Hours,Minutes)
 parseHM = (,) <$> decimal <* char ':' <*> decimal
 
+-- Parse the Timeunit part of a delay or repeater flag
 parseTimeUnit :: TP.Parser Text TimeUnit
 parseTimeUnit = choice [char 'h' *> pure UnitHour
                        ,char 'd' *> pure UnitDay
@@ -128,6 +155,8 @@ parseTimeUnit = choice [char 'h' *> pure UnitHour
                        ,char 'm' *> pure UnitMonth
                        ,char 'y' *> pure UnitYear]
 
+
+-- | Parse a repeater flag, e.g. ".+4w", or "++1y"
 parseRepeater :: TP.Parser Text Repeater
 parseRepeater = Repeater
                 <$> choice[string "++" *> pure RepeatCumulate
@@ -137,6 +166,7 @@ parseRepeater = Repeater
                 <*> decimal
                 <*> parseTimeUnit
 
+-- | Parse a delay flag, e.g. "--1d" or "-2w"
 parseDelay :: TP.Parser Text Delay
 parseDelay = Delay
              <$> choice [string "--" *> pure DelayFirst

--- a/src/Data/OrgMode/Parse/Attoparsec/Time.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Time.hs
@@ -20,11 +20,10 @@ import qualified Data.Attoparsec.ByteString as AB
 import           Data.Attoparsec.Text       as T
 import           Data.Attoparsec.Types      as TP (Parser)
 import qualified Data.ByteString.Char8      as BS
-import           Data.HashMap.Strict        (HashMap(..),fromList)
-import           Data.Maybe                 (listToMaybe, fromJust, isJust)
-import           Data.Text                  as Text (Text, isPrefixOf, unwords,
-                                                     pack, unpack, words)
-import           Data.Text.Encoding         (encodeUtf8)
+import           Data.HashMap.Strict        (HashMap,fromList)
+import           Data.Maybe                 (listToMaybe)
+import           Data.Text                  as Text (Text, unwords,
+                                                     pack, unpack )
 import           Data.Thyme.Calendar        (YearMonthDay(..))
 import           Data.Thyme.Format          (buildTime, timeParser)
 import           Data.Thyme.LocalTime       (Hours, Minutes)
@@ -96,6 +95,7 @@ parseBracketedDateTime = do
       return ( DateTime datePart dName (Just t1)repPart delPart
              , Just t2
              , activeBracket '<')
+    Nothing -> fail "Failed to parse a timestamp (HH:MM)"
 
     where activeBracket = (=='<')
           complementaryBracket '<' = '>'

--- a/src/Data/OrgMode/Parse/Attoparsec/Time.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Time.hs
@@ -24,7 +24,6 @@ import           Data.HashMap.Strict        (HashMap,fromList)
 import           Data.Maybe                 (listToMaybe)
 import           Data.Text                  as Text (Text, unwords,
                                                      pack, unpack )
-import           Data.Thyme.Calendar        (YearMonthDay(..))
 import           Data.Thyme.Format          (buildTime, timeParser)
 import           Data.Thyme.LocalTime       (Hours, Minutes)
 import           Prelude                    hiding (concat, null, takeWhile,

--- a/src/Data/OrgMode/Parse/Attoparsec/Time.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Time.hs
@@ -88,11 +88,11 @@ parseBracketedDateTime = do
 
   case timePart of
     Just (Left (h,m)) ->
-      return ( DateTime datePart dName (Just (h,m)) repPart delPart
+      return ( DateTime (YMD' datePart) dName (Just (h,m)) repPart delPart
              , Nothing
              , activeBracket '<')
     Just (Right (t1,t2)) ->
-      return ( DateTime datePart dName (Just t1)repPart delPart
+      return ( DateTime (YMD' datePart) dName (Just t1)repPart delPart
              , Just t2
              , activeBracket '<')
     Nothing -> fail "Failed to parse a timestamp (HH:MM)"

--- a/src/Data/OrgMode/Parse/Attoparsec/Time.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Time.hs
@@ -20,6 +20,7 @@ import qualified Data.Attoparsec.ByteString as AB
 import           Data.Attoparsec.Text       as T
 import           Data.Attoparsec.Types      as TP (Parser)
 import qualified Data.ByteString.Char8      as BS
+import           Data.HashMap.Strict        (fromList)
 import           Data.Maybe                 (listToMaybe, fromJust, isJust)
 import           Data.Text                  as Text (Text, isPrefixOf, unwords,
                                                      pack, unpack, words)
@@ -32,6 +33,15 @@ import           Prelude                    hiding (concat, null, takeWhile,
 import           System.Locale              (defaultTimeLocale)
 
 import           Data.OrgMode.Parse.Types
+
+
+parsePlannings :: TP.Parser Text (HashMap PlanningType Timestamp)
+parsePlannings = fromList <$> (many' (planning <* skipSpace))
+parsePlanning =  (,) <$> pType <* char ':' *> skipSpace *> parseTimestamp
+  where pType = choice [string "SCHEDULED" *> pure SCHEDULED
+                       ,string "DEADLINE"  *> pure DEADLINE
+                       ,string "CLOSED"    *> pure CLOSED
+                       ]
 
 parseTimestamp :: TP.Parser Text Timestamp
 parseTimestamp = do

--- a/src/Data/OrgMode/Parse/Attoparsec/Time.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Time.hs
@@ -36,7 +36,8 @@ import           Data.OrgMode.Parse.Types
 
 -- | Parse a planning line
 --
--- Plannings live in a heading section and are formatted as a keyword and a timestamp
+-- Plannings live in a heading section and are formatted as a keyword
+-- and a timestamp.
 -- There can be more than one, but they are all on the same line
 -- e.g. DEADLINE: <2015-05-10 17:00> CLOSED: <2015-04-16 12:00>
 parsePlannings :: TP.Parser Text (HashMap PlanningKeyword Timestamp)
@@ -112,12 +113,15 @@ parseBracketedDateTime = do
     Just (Left (h,m)) ->
       return ( DateTime (YMD' datePart) dName (Just (h,m)) repeatPart delayPart
              , Nothing
-             , activeBracket '<')
+             , activeBracket oBracket)
     Just (Right (t1,t2)) ->
       return ( DateTime (YMD' datePart) dName (Just t1)repeatPart delayPart
              , Just t2
-             , activeBracket '<')
-    Nothing -> fail "Failed to parse a timestamp (HH:MM)"
+             , activeBracket oBracket)
+    Nothing ->
+      return (DateTime (YMD' datePart) dName Nothing repeatPart delayPart
+             , Nothing
+             , activeBracket oBracket)
 
     where activeBracket = (=='<')
           complementaryBracket '<' = '>'

--- a/src/Data/OrgMode/Parse/Types.hs
+++ b/src/Data/OrgMode/Parse/Types.hs
@@ -68,8 +68,8 @@ type Clock      = (Maybe Timestamp, Maybe Duration)
 
 data Section = Section {
       sectionPlannings  :: Plannings
-    , sectionProperties :: Properties
     , sectionClocks     :: [Clock]
+    , sectionProperties :: Properties
     , sectionParagraph  :: Text
   } deriving (Show, Eq, Generic)
 

--- a/src/Data/OrgMode/Parse/Types.hs
+++ b/src/Data/OrgMode/Parse/Types.hs
@@ -22,6 +22,8 @@ module Data.OrgMode.Parse.Types
 , PlanningKeyword (..)
 , Timestamp    (..)
 , DateTime (..)
+, Stats (..)
+, Tag
 , TimeUnit (..)
 , RepeaterType (..)
 , Repeater (..)
@@ -33,8 +35,7 @@ import           Data.Hashable        (Hashable(..))
 import           Data.HashMap.Strict  (HashMap)
 import           Data.Text            (Text)
 import           Data.Thyme.Calendar  (YearMonthDay(..))
-import           Data.Thyme.LocalTime (LocalTime (..), Hour(..),Minute(..))
-import           Data.Tree            (Forest(..),Tree(..))
+import           Data.Thyme.LocalTime (Hour, Minute)
 import           GHC.Generics
 
 ----------------------------------------------------------------------------
@@ -56,7 +57,7 @@ data Heading = Heading
     , priority    :: Maybe Priority     -- Header line
     , title       :: Text               -- properties
     , stats       :: Maybe Stats        --
-    , tags        :: [Text]             --
+    , tags        :: [Tag]             --
     , section     :: Section            -- Next-line
     , subHeadings :: [Heading]          -- elements
     } deriving (Show, Eq, Generic)
@@ -70,8 +71,9 @@ data TodoKeyword = TODO
                  | OtherKeyword Text
   deriving (Show, Eq, Generic)
 
+type Tag = Text
 
-data Stats = StatsPtc Int
+data Stats = StatsPct Int
            | StatsOf  Int Int
            deriving (Show, Eq, Generic)
 

--- a/src/Data/OrgMode/Parse/Types.hs
+++ b/src/Data/OrgMode/Parse/Types.hs
@@ -1,13 +1,12 @@
------------------------------------------------------------------------------
--- |
--- Module      :  Data.OrgMode.Parse.Types
--- Copyright   :  © 2014 Parnell Springmeyer
--- License     :  All Rights Reserved
--- Maintainer  :  Parnell Springmeyer <parnell@digitalmentat.com>
--- Stability   :  stable
---
--- Types and utility functions.
-----------------------------------------------------------------------------
+{-|
+Module      :  Data.OrgMode.Parse.Types
+Copyright   :  © 2014 Parnell Springmeyer
+License     :  All Rights Reserved
+Maintainer  :  Parnell Springmeyer <parnell@digitalmentat.com>
+Stability   :  experimental
+
+Types and utility functions.
+-}
 
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveGeneric     #-}
@@ -48,15 +47,15 @@ import           Data.Traversable
 import           GHC.Generics
 
 data Document = Document {
-    documentText     :: Text
-  , documentHeadings :: [Heading]
+    documentText     :: Text      -- ^ Text occurring before any Org headlines
+  , documentHeadings :: [Heading] -- ^ Toplevel Org headlines
   } deriving (Show, Eq, Generic)
 
 
 data Heading = Heading
-    { level       :: Int                --
-    , keyword     :: Maybe StateKeyword --
-    , priority    :: Maybe Priority     -- Header line
+    { level       :: Int                -- ^ Org headline nesting level (1 is at the top)
+    , keyword     :: Maybe StateKeyword -- ^ State of the headline (e.g. TODO, DONE)
+    , priority    :: Maybe Priority     --
     , title       :: Text               -- properties
     , stats       :: Maybe Stats        --
     , tags        :: [Tag]             --

--- a/src/Data/OrgMode/Parse/Types.hs
+++ b/src/Data/OrgMode/Parse/Types.hs
@@ -51,6 +51,8 @@ data Document = Document {
   , documentHeadings :: [Heading] -- ^ Toplevel Org headlines
   } deriving (Show, Eq, Generic)
 
+instance A.ToJSON Document where
+instance A.FromJSON Document where
 
 data Heading = Heading
     { level       :: Int                -- ^ Org headline nesting level (1 is at the top)

--- a/src/Data/OrgMode/Parse/Types.hs
+++ b/src/Data/OrgMode/Parse/Types.hs
@@ -21,6 +21,7 @@ module Data.OrgMode.Parse.Types
 , TodoKeyword  (..)
 , Duration
 , PlanningKeyword (..)
+, Properties
 , Timestamp    (..)
 , DateTime (..)
 , Stats (..)
@@ -58,11 +59,13 @@ data Heading = Heading
     , subHeadings :: [Heading]          -- elements
     } deriving (Show, Eq, Generic)
 
+type Properties = HashMap Text Text
+type Clock      = (Maybe Timestamp, Maybe Duration)
 
 data Section = Section {
       sectionPlannings  :: Plannings
-    , sectionProperties :: HashMap Text         Text
-    , sectionClocks     :: [(Maybe Timestamp, Maybe Duration)]
+    , sectionProperties :: Properties
+    , sectionClocks     :: [Clock]
     , sectionParagraph  :: Text
   } deriving (Show, Eq, Generic)
 

--- a/src/Data/OrgMode/Parse/Types.hs
+++ b/src/Data/OrgMode/Parse/Types.hs
@@ -13,19 +13,13 @@
 {-# LANGUAGE DeriveGeneric     #-}
 
 module Data.OrgMode.Parse.Types
-( OrgDocument (..)
-, OrgSection (..)
+( Document (..)
+, Section (..)
 , Heading  (..)
 , Priority (..)
-, State    (..)
-, Keyword  (..)
-, PropertyDrawer (..)
-, Schedule     (..)
-, ScheduleType (..)
+, TodoKeyword  (..)
+, Duration
 , Timestamp    (..)
-, Open         (..)
-, Close        (..)
-, toPriority
 , DateTime (..)
 , TimeUnit (..)
 , RepeaterType (..)
@@ -42,55 +36,47 @@ import           Data.Tree            (Forest(..),Tree(..))
 import           GHC.Generics
 
 ----------------------------------------------------------------------------
-data OrgDocument = OrgDocument {
-  headings :: Forest OrgSection
-  } deriving (Show, Eq)
+data Document = Document {
+    openingText :: Text
+  , topHeadings :: [Heading]
+  } deriving (Show, Eq, Generic)
 
-data OrgSection = OrgSection {
-      sectionHeading  :: Heading
-    , sectionElements :: [Element]
-  } deriving (Show, Eq)
+data Section = Section {
+      sectionPlannings  :: HashMap PlanningKeyword Timestamp
+    , sectionProperties :: HashMap Text         Text
+    , sectionClocks     :: [(Maybe Timestamp, Maybe Duration)]
+    , sectionParagraph  :: Text
+  } deriving (Show, Eq, Generic)
 
 data Heading = Heading
-    { level    :: Int
-    , keyword  :: Maybe TodoKeyword
-    , priority :: Maybe Priority
-    , title    :: Text
-    , tags     :: [Text]
-    , stats    :: Maybe Stats
-    } deriving (Show, Eq)
+    { level       :: Int                --
+    , keyword     :: Maybe TodoKeyword  --
+    , priority    :: Maybe Priority     -- Header line
+    , title       :: Text               -- properties
+    , stats       :: Maybe Stats        --
+    , tags        :: [Text]             --
+    , section     :: Section            -- Next-line
+    , subHeadings :: [Heading]          -- elements
+    } deriving (Show, Eq, Generic)
 
 
 data Priority = A | B | C
-  deriving (Show, Read, Eq, Ord)
+  deriving (Show, Read, Eq, Ord, Generic)
 
 data TodoKeyword = TODO
                  | DONE
                  | OtherKeyword Text
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
 
-newtype Keyword = Keyword Text
-  deriving (Show, Eq, Ord)
-
--- TODO Parse priority rather than pattern matching here
-toPriority :: Text -> Priority
-toPriority "A" = A
-toPriority "B" = B
-toPriority "C" = C
 
 data Stats = StatsPtc Int
            | StatsOf  Int Int
-           deriving (Eq, Show, Generic)
+           deriving (Show, Eq, Generic)
 
-----------------------------------------------------------------------------
-data Element = Clock    (Maybe Timestamp) (Maybe Duration)
-             | Planning [(PlanningType, Maybe Timestamp)]
-             | PropertyDrawer (HashMap Text Text)
-             deriving (Eq, Show, Generic)
 
 type Duration = (Hour,Minute)
 
-data PlanningType = SCHEDULED | DEADLINE | APPOINTMENT
+data PlanningKeyword = SCHEDULED | DEADLINE | CLOSED
   deriving (Show, Eq, Generic)
 
 -- -- This might be the form to use if we were supporting <diary> timestamps
@@ -102,7 +88,7 @@ data Timestamp = Timestamp {
     tsTime    :: DateTime
   , tsActive  :: Bool
   , tsEndTime :: Maybe DateTime
-  } deriving (Eq, Show)
+  } deriving (Show, Eq, Generic)
 
 data DateTime = DateTime {
     yearMonthDay :: YearMonthDay
@@ -110,82 +96,29 @@ data DateTime = DateTime {
   , hourMinute   :: Maybe (Hour,Minute)
   , repeater     :: Maybe Repeater
   , delay        :: Maybe Delay
-  } deriving (Eq, Show)
+  } deriving (Show, Eq, Generic)
 
 data TimeUnit = UnitYear
               | UnitWeek
               | UnitMonth
               | UnitDay
               | UnitHour
-              deriving (Eq, Show, Generic)
+              deriving (Show, Eq, Generic)
 
 data RepeaterType = RepeatCumulate | RepeatCatchUp | RepeatRestart
-                  deriving (Eq, Show, Generic)
+                  deriving (Show, Eq, Generic)
 
 data Repeater = Repeater {
     repeaterType  :: RepeaterType
   , repeaterValue :: Int
   , repeaterUnit  :: TimeUnit
-  } deriving (Eq, Show, Generic)
+  } deriving (Show, Eq, Generic)
 
 data DelayType = DelayAll | DelayFirst
-               deriving (Eq, Show, Generic)
+               deriving (Show, Eq, Generic)
 
 data Delay = Delay {
     delayType  :: DelayType
   , delayValue :: Int
   , delayUnit  :: TimeUnit
-  } deriving (Eq, Show, Generic)
-
-
-
-data ClockEntry = ClockOngoing LocalTime
-                | ClockInterval (LocalTime,LocalTime)
-                deriving (Show, Eq)
-
--- instance A.ToJSON OrgSection where
---   toJSON (OrgSection secHead secProps secSched secClocks) =
---     A.Object ["heading"    .= A.toJSON secHead
---              ,"properties" .= A.toJSON segProps
---              ,"schedules"  .= A.toJSON secSched
---              ,"clocks"     .= A.toJSON segClocks
---              ]
-
--- instance A.ToJSON Heading where
---   toJSON (Heading hLevel hPr hTodoState hTitle hTags) =
---     A.Object ["level"     .= A.Number hLevel
---              ,"priority"  .= A.toJSON hPr
---              ,"todoState" .= A.toJSON hTodoState
---              ,"title"     .= A.Text hTitle
---              ,"tags"      .= A.toJSON hTags
---              ]
-
--- instance A.ToJSON Schedule where
---   toJSON (Schedule sType sTs sRecur) =
---     A.Object ["type"  .= show sType
---              ,"time"    .= A.toJSON sTs
---              ,"recur" .= A.toJSON sRecur
---              ]
-
--- instance A.ToJSON Timestamp where
---   toJSON (Active t)   = A.Object
---                         ["timestamp"       .= show t
---                         ,"timestampActive" .= True]
---   toJSON (Inactive t) = A.Object
---                         ["timestamp"       .= show t
---                         ,"timestampActive" .= False]
-
--- instance A.ToJSON v => A.ToJSON PropertDrawer Text v where
---   toJSON (PropertyDrawer m) = A.toJSON m
-
--- instance A.ToJSON Priority where
---   toJSON A = A.String "A"
---   toJSON B = A.String "B"
---   toJSON C = A.String "C"
---   toJSON _ = A.Null
-
--- instance A.ToJSON ClockEntry where
---   toJSON (ClockOngoing t) =
---       A.Array [A.toJSON t]
---     toJSON (ClockInterval (t1,t2)) =
---       A.Array (map A.toJSON [t1,t2])
+  } deriving (Show, Eq, Generic)

--- a/src/Data/OrgMode/Parse/Types.hs
+++ b/src/Data/OrgMode/Parse/Types.hs
@@ -19,6 +19,7 @@ module Data.OrgMode.Parse.Types
 , Priority (..)
 , TodoKeyword  (..)
 , Duration
+, PlanningKeyword (..)
 , Timestamp    (..)
 , DateTime (..)
 , TimeUnit (..)
@@ -28,6 +29,7 @@ module Data.OrgMode.Parse.Types
 , Delay (..)
 ) where
 
+import           Data.Hashable        (Hashable(..))
 import           Data.HashMap.Strict  (HashMap)
 import           Data.Text            (Text)
 import           Data.Thyme.Calendar  (YearMonthDay(..))
@@ -77,7 +79,10 @@ data Stats = StatsPtc Int
 type Duration = (Hour,Minute)
 
 data PlanningKeyword = SCHEDULED | DEADLINE | CLOSED
-  deriving (Show, Eq, Generic)
+  deriving (Show, Eq, Enum, Ord, Generic)
+
+instance Hashable PlanningKeyword where
+  hashWithSalt salt k = hashWithSalt salt (fromEnum k)
 
 -- -- This might be the form to use if we were supporting <diary> timestamps
 -- data Timestamp = Dairy Text

--- a/src/Data/OrgMode/Parse/Types.hs
+++ b/src/Data/OrgMode/Parse/Types.hs
@@ -28,8 +28,19 @@ module Data.OrgMode.Parse.Types
 import           Data.HashMap.Strict  (HashMap)
 import           Data.Text            (Text)
 import           Data.Thyme.LocalTime (LocalTime (..))
+import           Data.Tree            (Forest(..),Tree(..))
 
 ----------------------------------------------------------------------------
+data OrgDocument = OrgDocument {
+  headings :: Forest OrgSection
+  } deriving (Show, Eq)
+
+data OrgSection = OrgSection {
+    sectionHeading :: Heading
+  , sectionPropertyDrawer :: Maybe (PropertyDrawer Text Text)
+  , sectionSchedules :: [Schedule]
+  , sectionClockEntries :: [ClockEntry]
+  } deriving (Show, Eq)
 
 data Heading = Heading
     { level    :: Int
@@ -75,3 +86,7 @@ data Timestamp = Active LocalTime | Inactive LocalTime
 
 newtype Open = Open Char
 newtype Close = Close Char
+
+data ClockEntry = ClockOngoing LocalTime
+                | ClockInterval (LocalTime,LocalTime)
+                deriving (Show, Eq)

--- a/src/Data/OrgMode/Parse/Types.hs
+++ b/src/Data/OrgMode/Parse/Types.hs
@@ -18,7 +18,7 @@ module Data.OrgMode.Parse.Types
 , Heading  (..)
 , Priority (..)
 , Plannings (..)
-, TodoKeyword  (..)
+, StateKeyword  (..)
 , Duration
 , PlanningKeyword (..)
 , Properties
@@ -55,7 +55,7 @@ data Document = Document {
 
 data Heading = Heading
     { level       :: Int                --
-    , keyword     :: Maybe TodoKeyword  --
+    , keyword     :: Maybe StateKeyword --
     , priority    :: Maybe Priority     -- Header line
     , title       :: Text               -- properties
     , stats       :: Maybe Stats        --
@@ -157,13 +157,11 @@ instance A.FromJSON TimeUnit where
 --instance A.ToJSON Document where
 --instance A.FromJSON Document where
 
-data TodoKeyword = TODO
-                 | DONE
-                 | OtherKeyword Text
+newtype StateKeyword = StateKeyword {unStateKeyword :: Text}
   deriving (Show, Eq, Generic)
 
-instance A.ToJSON TodoKeyword where
-instance A.FromJSON TodoKeyword where
+instance A.ToJSON StateKeyword where
+instance A.FromJSON StateKeyword where
 
 
 data PlanningKeyword = SCHEDULED | DEADLINE | CLOSED

--- a/src/Data/OrgMode/Parse/Types.hs
+++ b/src/Data/OrgMode/Parse/Types.hs
@@ -47,6 +47,11 @@ import           Data.Thyme.LocalTime (Hour, Minute)
 import           Data.Traversable
 import           GHC.Generics
 
+data Document = Document {
+    openingText :: Text
+  , topHeadings :: [Heading]
+  } deriving (Show, Eq, Generic)
+
 
 data Heading = Heading
     { level       :: Int                --
@@ -149,11 +154,6 @@ instance A.ToJSON TimeUnit where
 instance A.FromJSON TimeUnit where
 
 ---------------------------------------------------------------------------
-data Document = Document {
-    openingText :: Text
-  , topHeadings :: [Heading]
-  } deriving (Show, Eq, Generic)
-
 --instance A.ToJSON Document where
 --instance A.FromJSON Document where
 

--- a/src/Data/OrgMode/Parse/Types.hs
+++ b/src/Data/OrgMode/Parse/Types.hs
@@ -48,8 +48,8 @@ import           Data.Traversable
 import           GHC.Generics
 
 data Document = Document {
-    openingText :: Text
-  , topHeadings :: [Heading]
+    documentText     :: Text
+  , documentHeadings :: [Heading]
   } deriving (Show, Eq, Generic)
 
 

--- a/test/Document.hs
+++ b/test/Document.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Document where
+
+import Control.Applicative
+import Data.Attoparsec.Text
+import Data.Monoid
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Data.OrgMode.Parse.Types
+import Data.OrgMode.Parse.Attoparsec.Document
+import Util
+
+parserSmallDocumentTests :: TestTree
+parserSmallDocumentTests = testGroup "Attoparsec Small Document"
+  [ (testCase "Parse Empty Document" $ testDocS "" (Document mempty mempty))
+  , (testCase "Parse No Headlines"   $ testDocS pText (Document pText []))
+  ]
+  where testDocS s r = expectParse (parseDocument kw) s (Right r)
+        testDocF s   = expectParse (parseDocument kw) s (Left "Some failure")
+        kw           = ["TODO", "CANCELED", "DONE"]
+        pText        = "Paragraph text\n.No headline here.\n##--------\n"

--- a/test/Document.hs
+++ b/test/Document.hs
@@ -19,7 +19,7 @@ parserSmallDocumentTests = testGroup "Attoparsec Small Document"
   [ testCase "Parse Empty Document"   $ testDocS "" (Document "" [])
   , testCase "Parse No Headlines"     $ testDocS pText (Document pText [])
   , testCase "Parse Heading Sample A" $ testDocS sampleAText sampleAParse
-  , testCase "Parse Heading no \n"    $    -- TODO This test fails
+  , testCase "Parse Heading no \n"    $
       testDocS "* T" (Document "" [emptyHeading {title="T"}])
   ]
   where testDocS s r = expectParse (parseDocument kw) s (Right r)

--- a/test/Document.hs
+++ b/test/Document.hs
@@ -5,6 +5,8 @@ module Document where
 import Control.Applicative
 import Data.Attoparsec.Text
 import Data.Monoid
+import Data.Text
+import qualified Data.Text as Text
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -14,10 +16,49 @@ import Util
 
 parserSmallDocumentTests :: TestTree
 parserSmallDocumentTests = testGroup "Attoparsec Small Document"
-  [ (testCase "Parse Empty Document" $ testDocS "" (Document mempty mempty))
-  , (testCase "Parse No Headlines"   $ testDocS pText (Document pText []))
+  [ testCase "Parse Empty Document"   $ testDocS "" (Document "" [])
+  , testCase "Parse No Headlines"     $ testDocS pText (Document pText [])
+  , testCase "Parse Heading Sample A" $ testDocS sampleAText sampleAParse
+  , testCase "Parse Heading no \n"    $    -- TODO This test fails
+      testDocS "* T" (Document "" [emptyHeading {title="T"}])
   ]
   where testDocS s r = expectParse (parseDocument kw) s (Right r)
         testDocF s   = expectParse (parseDocument kw) s (Left "Some failure")
         kw           = ["TODO", "CANCELED", "DONE"]
         pText        = "Paragraph text\n.No headline here.\n##--------\n"
+
+
+sampleAText :: Text
+sampleAText = Text.concat [sampleParagraph,"* Test1", spaces 20,":Hi there:\n"
+                          ,"*\n"
+                          ," *\n"
+                          ,"* Test2    :Two:Tags:\n"
+                          ]
+sampleAParse :: Document
+sampleAParse = Document
+               sampleParagraph
+               [emptyHeading {title="Test1", tags=["Hi there"]}
+               ,emptyHeading
+               ,emptyHeading
+               ,emptyHeading {title="Test2", tags=["Two","Tags"]}
+               ]
+
+emptyHeading :: Heading
+emptyHeading = Heading {level = 1
+                       ,keyword     = Nothing
+                       ,priority    = Nothing
+                       ,title       = ""
+                       ,stats       = Nothing
+                       ,tags        = []
+                       ,section     = emptySection
+                       ,subHeadings = []
+                       }
+
+sampleParagraph :: Text
+sampleParagraph = "This is some sample text in a paragraph.\n\n"
+
+spaces :: Int -> Text
+spaces = flip Text.replicate " "
+
+emptySection :: Section
+emptySection = Section (Plns mempty) mempty mempty mempty

--- a/test/Headings.hs
+++ b/test/Headings.hs
@@ -20,4 +20,4 @@ parserHeadingTests = testGroup "Attoparsec Heading"
     , (testCase "Parse Heading Full"                $ testHeading "* DONE [#B] A heading : with [[http://somelink.com][a link]] :WITH:KEYWORDS:\n")
     ]
   where
-    testHeading = testParser (heading)
+    testHeading = testParser (headingBelowLevel ["TODO","CANCELED","DONE"] 0)

--- a/test/Headings.hs
+++ b/test/Headings.hs
@@ -18,6 +18,7 @@ parserHeadingTests = testGroup "Attoparsec Heading"
     , (testCase "Parse Heading w/ State"            $ testHeading "* CANCELED An important heading with just state\n")
     , (testCase "Parse Heading w/ Keywords"         $ testHeading "* An important heading :WITH:KEYWORDS:\n")
     , (testCase "Parse Heading Full"                $ testHeading "* DONE [#B] A heading : with [[http://somelink.com][a link]] :WITH:KEYWORDS:\n")
+    , (testCase "Parse Heading All But Title"       $ testHeading "* DONE [#A] :WITH:KEYWORDS:\n")
     ]
   where
     testHeading = testParser (headingBelowLevel ["TODO","CANCELED","DONE"] 0)

--- a/test/PropertyDrawer.hs
+++ b/test/PropertyDrawer.hs
@@ -17,4 +17,4 @@ parserPropertyDrawerTests = testGroup "Attoparsec PropertyDrawer"
   where
     emptyDrawer = ":PROPERTIES:\n:END:\n"
     drawerWKeys = ":PROPERTIES:\n    :URL: http://someurl.com?query\n :notes: you should be taking them\n:END:\n"
-    testProps = testParser (drawer)
+    testProps = testParser (parseDrawer)

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -7,6 +7,7 @@ import           Headings
 import           PropertyDrawer
 import           Test.Tasty
 import           Timestamps
+import           Document
 
 main :: IO ()
 main = defaultMain tests
@@ -17,4 +18,5 @@ tests = testGroup
           [ parserHeadingTests
           , parserPropertyDrawerTests
           , parserTimestampTests
+          , parserSmallDocumentTests
           ]

--- a/test/Timestamps.hs
+++ b/test/Timestamps.hs
@@ -12,13 +12,19 @@ import           Test.Tasty.HUnit
 
 import           Util
 
-parserTimestampTests :: TestTree
-parserTimestampTests = testGroup "Attoparsec Timestamp"
-    [ (testCase "Parse Timestamp Schedule"          $ testTimestamp "SCHEDULED: <2004-02-29 Sun>\n")
-    , (testCase "Parse Timestamp Deadline"          $ testTimestamp "DEADLINE: <2004-02-29 Sun>\n")
-    , (testCase "Parse Timestamp Appointment"       $ testTimestamp "<2004-02-29 Sun>\n")
-    , (testCase "Parse Timestamp Recurring"         $ testTimestamp "<2004-02-29 Sun +1w>\n")
-    , (testCase "Parse Timestamp Full"              $ testTimestamp "SCHEDULED: <2004-02-29 Sun +1w>\n")
+parserPlanningTests :: TestTree
+parserPlanningTests = testGroup "Attoparsec Planning"
+    [ (testCase "Parse Planning Schedule" $ testPlanning "SCHEDULED: <2004-02-29 Sun>")
+    , (testCase "Parse Planning Deadline" $ testPlanning "DEADLINE: <2004-02-29 Sun>")
+    , (testCase "Parse Planning Full"     $ testPlanning "SCHEDULED: <2004-02-29 Sun +1w>")
     ]
   where
-    testTimestamp t = testParser (parseTimestamp (Open '<') (Close '>') <* endOfLine) t
+    testPlanning t = testParser parsePlannings t
+
+parserTimestampTests :: TestTree
+parserTimestampTests = testGroup "Attoparsec Timestamp"
+    [ (testCase "Parse Timestamp Appointment" $ testTimestamp "<2004-02-29 Sun>\n")
+    , (testCase "Parse Timestamp Recurring"   $ testTimestamp "<2004-02-29 Sun +1w>\n")
+    ]
+  where
+    testTimestamp t = testParser (parseTimestamp <* endOfLine) t

--- a/test/Timestamps.hs
+++ b/test/Timestamps.hs
@@ -5,6 +5,7 @@ module Timestamps where
 
 import           Control.Applicative      ((<*))
 import           Data.Attoparsec.Text     (endOfLine)
+import           Data.HashMap.Strict
 import           Data.OrgMode.Parse
 import           Data.OrgMode.Parse.Types
 import           Test.Tasty
@@ -17,9 +18,22 @@ parserPlanningTests = testGroup "Attoparsec Planning"
     [ (testCase "Parse Planning Schedule" $ testPlanning "SCHEDULED: <2004-02-29 Sun>")
     , (testCase "Parse Planning Deadline" $ testPlanning "DEADLINE: <2004-02-29 Sun>")
     , (testCase "Parse Planning Full"     $ testPlanning "SCHEDULED: <2004-02-29 Sun +1w>")
+    , (testCase "Parse Sample Schedule"   $ testPlanningS sExampleStrA sExampleResA)
     ]
   where
-    testPlanning t = testParser parsePlannings t
+    testPlanning  t   = testParser parsePlannings t
+    testPlanningS t r = expectParse parsePlannings t (Right r)
+
+(sExampleStrA, sExampleResA) =
+  ("SCHEDULED: <2004-02-29 Sun 10:20 +1w -2d>"
+   ,(fromList [(SCHEDULED, Timestamp
+                                (DateTime
+                                 (YMD' (YearMonthDay 2004 2 29))
+                                 (Just "Sun")
+                                 (Just (10,20))
+                                 (Just (Repeater RepeatCumulate 1 UnitWeek))
+                                 (Just (Delay DelayAll 2 UnitDay))
+                                )True Nothing)]))
 
 parserTimestampTests :: TestTree
 parserTimestampTests = testGroup "Attoparsec Timestamp"

--- a/test/Util.hs
+++ b/test/Util.hs
@@ -2,11 +2,23 @@ module Util where
 
 import           Data.Attoparsec.Text
 import           Data.Attoparsec.Types as TP
+import           Data.Either
 import           Data.Text             as T
 import           Test.HUnit
 
 testParser :: (TP.Parser Text a) -> String -> Assertion
 testParser f v = fromEither (parseOnly f $ T.pack v)
+
+expectParse :: (Eq a, Show a) => TP.Parser Text a -- ^ Parser under test
+                              -> Text             -- ^ Message under test
+                              -> Either String a  -- ^ Expected parse result
+                              -> Assertion
+expectParse p t (Left _)  = assertBool "Expected parse failure"
+                            (isLeft (parseOnly p t))
+expectParse p t a         = assertBool msg (r == a)
+  where r   = parseOnly p t
+        msg = Prelude.unwords
+              ["Expected parse to", show a, ". Got", show r]
 
 fromEither :: Either String a -> Assertion
 fromEither (Left e)  = assertBool e  False


### PR DESCRIPTION
Here it is! Tested out with some non-trivial files. I'm sure there are some corner cases to work through but I think this is a good place to check-in, and we can put more thorough tests up (especially cases that we extract from failures on real-world files) as we go.

The last unresolved issue is that matter about whether 
** My headilne  :THESE:THINGS:
Are called keywords or Tags. I got the Tags nomenclature from the orgmode syntax draft, but I wonder if there's some other source that calls them keywords, or if they're commonly called keywords by users and the orgmode syntax draft is out of date. Anyhow, I'm open to tweaking that and would definitely appreciate if you know of other sites that tried to formalize these terms.

Found your orgmode-grammar package - neat :)