### PR TITLE
Support Japanese weekdays.

### DIFF
--- a/src/Data/OrgMode/Parse/Attoparsec/Section.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Section.hs
@@ -13,7 +13,7 @@
 
 module Data.OrgMode.Parse.Attoparsec.Section where
 
-import           Control.Applicative                          ((<$>), (<*>))
+import           Control.Applicative                          ((<$>), (<*>), (<|>))
 import           Data.Attoparsec.Text                         as T
 import           Data.Attoparsec.Types                        as TP
 import           Data.Monoid                                  (mempty)
@@ -37,4 +37,9 @@ parseSection = Section
                <*> option mempty parseDrawer
                <*> (unlines <$> many' nonHeaderLine)
   where
-    nonHeaderLine = pack <$> manyTill (notChar '*') endOfLine
+    nonHeaderLine = nonHeaderLine0 <|> nonHeaderLine1
+    nonHeaderLine0 = endOfLine >> return (pack "")
+    nonHeaderLine1 = pack <$> do
+      h <- notChar '*'
+      t <- manyTill anyChar endOfLine
+      return (h:t)

--- a/src/Data/OrgMode/Parse/Attoparsec/Time.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Time.hs
@@ -170,9 +170,11 @@ transformBracketedDateTime
             , Nothing
             , act)
 
--- | Parse a 3-character day name.
+-- | Parse a day name. TODO: support more languages.
 parseDay :: TP.Parser Text Text
-parseDay = choice (map string ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"])
+parseDay = choice $ map string $
+  ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat",
+   "日", "月", "火", "水", "木", "金", "土"]
 
 type AbsoluteTime   = (Hours, Minutes)
 type TimestampRange = (AbsoluteTime, AbsoluteTime)

--- a/test/Document.hs
+++ b/test/Document.hs
@@ -38,8 +38,7 @@ sampleAParse :: Document
 sampleAParse = Document
                sampleParagraph
                [emptyHeading {title="Test1", tags=["Hi there"]}
-               ,emptyHeading
-               ,emptyHeading
+               ,emptyHeading {section=emptySection{sectionParagraph=" *\n"}}
                ,emptyHeading {title="Test2", tags=["Two","Tags"]}
                ]
 


### PR DESCRIPTION
I've been using org-mode for about a month, and when I started to apply detailed analysis to my .org files I found this library was very useful --- except that it didn't parse any timestamps.

The cause of the problem is that the library cannot recognize Japanese weekdays. This patch contains simple solution that fixes the problem.

Given that org-mode is used in many languages (see e.g. the official website http://orgmode.org/) this library will prosper even more, if it can support other languages. Surely, adding Japanese is not enough. There are some possible ways to extend this patch:

* To gradually add support to other locales, probably on demand.
* To support some general approach, like to regard any non-digit one-word as a weekday. I hope this is enough, judging from the official document http://orgmode.org/manual/Timestamps.html 
* others ...

I'd follow what Parnell (package maintainer) would decide.
