### PR TITLE
Improve the parsing of headings.

### DIFF
--- a/src/Data/OrgMode/Parse/Attoparsec/Section.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Section.hs
@@ -13,7 +13,7 @@
 
 module Data.OrgMode.Parse.Attoparsec.Section where
 
-import           Control.Applicative                          ((<$>), (<*>))
+import           Control.Applicative                          ((<$>), (<*>), (<|>))
 import           Data.Attoparsec.Text                         as T
 import           Data.Attoparsec.Types                        as TP
 import           Data.Monoid                                  (mempty)
@@ -37,4 +37,9 @@ parseSection = Section
                <*> option mempty parseDrawer
                <*> (unlines <$> many' nonHeaderLine)
   where
-    nonHeaderLine = pack <$> manyTill (notChar '*') endOfLine
+    nonHeaderLine = nonHeaderLine0 <|> nonHeaderLine1
+    nonHeaderLine0 = endOfLine >> return (pack "")
+    nonHeaderLine1 = pack <$> do
+      h <- notChar '*'
+      t <- manyTill anyChar endOfLine
+      return (h:t)

--- a/test/Document.hs
+++ b/test/Document.hs
@@ -38,8 +38,7 @@ sampleAParse :: Document
 sampleAParse = Document
                sampleParagraph
                [emptyHeading {title="Test1", tags=["Hi there"]}
-               ,emptyHeading
-               ,emptyHeading
+               ,emptyHeading {section=emptySection{sectionParagraph=" *\n"}}
                ,emptyHeading {title="Test2", tags=["Two","Tags"]}
                ]
 


### PR DESCRIPTION
_Problem_ : At the moment, a text line does not parse as a `nonHeaderLine` if an asterisk is found anywhere in the line. For example " I have computed (6*7).  " is not a `nonHeaderLine` , and the parsing of the section paragraph ends before this line. This is not wanted.

The patch will fix this issue.

From the org-mode documentation:

http://orgmode.org/manual/Headlines.html#Headlines

and from how the heading color changes in emacs, I think the heading line should start with an asterisk '*' with no whitespace before it. This patch will change the parsing of lines that starts with some whitespaces and then asterisks, from heading lines to non-heading lines.

I have updated the test accordingly so that the tests will pass.