### PR TITLE
Parse the text occurring before org headlines with *.

### DIFF
--- a/src/Data/OrgMode/Parse/Attoparsec/Document.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Document.hs
@@ -9,6 +9,7 @@ import           Prelude                                 hiding (unlines)
 import           Data.Text                               (Text, pack, unlines)
 import           Data.OrgMode.Parse.Types
 import           Data.OrgMode.Parse.Attoparsec.Headings
+import           Data.OrgMode.Parse.Attoparsec.Section (nonHeaderLine)
 
 ------------------------------------------------------------------------------
 parseDocument :: [Text] -> TP.Parser Text Document
@@ -16,6 +17,3 @@ parseDocument otherKeywords =
   Document
     <$> (unlines <$> many' nonHeaderLine)
     <*> many' (headingBelowLevel otherKeywords 0)
-
-nonHeaderLine :: TP.Parser Text Text
-nonHeaderLine = pack <$> manyTill (notChar '*') endOfLine

--- a/src/Data/OrgMode/Parse/Attoparsec/Section.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Section.hs
@@ -37,7 +37,11 @@ parseSection = Section
                <*> option mempty parseDrawer
                <*> (unlines <$> many' nonHeaderLine)
   where
-    nonHeaderLine = nonHeaderLine0 <|> nonHeaderLine1
+
+-- | Parse a non-heading line of a section.
+nonHeaderLine :: TP.Parser Text Text
+nonHeaderLine = nonHeaderLine0 <|> nonHeaderLine1
+  where
     nonHeaderLine0 = endOfLine >> return (pack "")
     nonHeaderLine1 = pack <$> do
       h <- notChar '*'

--- a/test/Document.hs
+++ b/test/Document.hs
@@ -54,7 +54,7 @@ emptyHeading = Heading {level = 1
                        }
 
 sampleParagraph :: Text
-sampleParagraph = "This is some sample text in a paragraph.\n\n"
+sampleParagraph = "This is some sample text in a paragraph which may contain * , : , and other special characters.\n\n"
 
 spaces :: Int -> Text
 spaces = flip Text.replicate " "


### PR DESCRIPTION
Hi @ixmatus ,

This will apply the fix #5 also to the text before org header.
To do this I have made `nonHeaderLine` public; please do what you want if you'd like other design.

I have also updated the test, so that `*` may be used in many places.
