### PR TITLE
Fix ambiguous foldable bug

### DIFF
--- a/src/Data/OrgMode/Parse/Attoparsec/Time.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Time.hs
@@ -176,7 +176,9 @@ parseDay :: TP.Parser Text Text
 parseDay = pack <$> some (TP.satisfyElem isDayChar)
   where
     isDayChar :: Char -> Bool
-    isDayChar c = not (c `elem` "]+0123456789>\r\n -")
+    isDayChar = (`notElem` nonDayChars)
+    nonDayChars :: String
+    nonDayChars = "]+0123456789>\r\n -"
     -- The above syntax is based on [^]+0-9>\r\n -]+
     -- a part of regexp named org-ts-regexp0
     -- in org.el .

--- a/test/Timestamps.hs
+++ b/test/Timestamps.hs
@@ -49,7 +49,8 @@ parserTimestampTests = testGroup "Attoparsec Timestamp"
 
 parserWeekdayTests :: TestTree
 parserWeekdayTests = testGroup "Attoparsec Weekday"
-  [testCase ("Parse Weekday in " ++ loc) $ mkTest w | (loc,ws) <- weekdays, w <- ws, isOrgParsable w]
+  [testCase ("Parse Weekday in " ++ loc) $ mkTest w
+  | (loc,ws) <- weekdays, w <- ws, isOrgParsable w]
   where
     mkTest w = expectParse parseTimestamp str (Right res)
       where
@@ -61,4 +62,5 @@ parserWeekdayTests = testGroup "Attoparsec Weekday"
                          Nothing
                          Nothing) True Nothing
 
-    isOrgParsable w = T.find (\c -> c `elem` "]+0123456789>\r\n -") w == Nothing
+    dayChars = "]+0123456789>\r\n -" :: String
+    isOrgParsable w = T.find (\c -> c `elem` dayChars) w == Nothing


### PR DESCRIPTION
Added a couple type annotations, as I was getting this ambiguous Foldable instance error on ghc-7.10

```
test/Timestamps.hs:64:39:
    No instance for (Foldable t0) arising from a use of ‘elem’
    The type variable ‘t0’ is ambiguous
```