### PR TITLE
Fix colon end fail parse

### DIFF
--- a/src/Data/OrgMode/Parse/Attoparsec/Headings.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Headings.hs
@@ -154,8 +154,10 @@ parseTags :: TP.Parser Text [Tag]
 parseTags = tags' >>= test
   where
     tags' = (char ':' *> takeWhile (/= '\n'))
-    test t | (Text.last t /= ':' || Text.length t < 2) = fail "Not a valid tag set"
-           | otherwise = return (splitOn ":" (Text.init t))
+    test t
+       | Text.null t = fail "no data after ':'"
+       | (Text.last t /= ':' || Text.length t < 2) = fail "Not a valid tag set"
+       | otherwise = return (splitOn ":" (Text.init t))
 
 skipSpace' :: TP.Parser Text ()
 skipSpace' = void $ takeWhile spacePred

--- a/test/Headings.hs
+++ b/test/Headings.hs
@@ -12,6 +12,7 @@ import           Util
 parserHeadingTests :: TestTree
 parserHeadingTests = testGroup "Attoparsec Heading"
     [ (testCase "Parse Heading Bare"                $ testHeading "* This is a title\n")
+    , (testCase "Parse Heading Bare with end colon" $ testHeading "* This heading ends in a colon:")
     , (testCase "Parse Heading Bare w/ Levels"      $ testHeading "*** This is a title\n")
     , (testCase "Parse Heading w/ Priority"         $ testHeading "* [#A] An important heading\n")
     , (testCase "Parse Heading w/ Priority & State" $ testHeading "* TODO [#A] An important heading with a state indicator\n")


### PR DESCRIPTION
I noticed that I  couldn't parse headings like 
* Some heading value: 

so I wrote a test case and a fix.